### PR TITLE
Improve search relevance scoring

### DIFF
--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -2,12 +2,22 @@ use crate::history::Conversation;
 use chrono::{DateTime, Duration, Local};
 use rayon::prelude::*;
 
+/// Size of the "topic window" — the first ~2000 characters of a conversation,
+/// covering the initial exchanges where the user establishes intent.
+const TOPIC_WINDOW_SIZE: usize = 2000;
+
+/// How much extra weight topic-window matches get over body matches.
+const TOPIC_WEIGHT: f64 = 3.0;
+
 /// Precomputed search data for a conversation
 pub struct SearchableConversation {
     /// Lowercased full text for searching
     pub text_lower: String,
     /// Original full text (moved from Conversation to avoid duplication)
     pub full_text: String,
+    /// Byte offset where the topic window ends in `text_lower`.
+    /// Matches within `text_lower[..topic_end]` are weighted higher.
+    pub topic_end: usize,
     /// Original conversation index
     pub index: usize,
 }
@@ -34,9 +44,21 @@ pub fn precompute_search_text(conversations: &mut [Conversation]) -> Vec<Searcha
         .map(|(idx, conv)| {
             let full_text = std::mem::take(&mut conv.full_text);
             let text_lower = normalize_for_search(&full_text);
+            // Find a char-boundary at or after TOPIC_WINDOW_SIZE bytes
+            let topic_end = if text_lower.len() <= TOPIC_WINDOW_SIZE {
+                text_lower.len()
+            } else {
+                // Advance past TOPIC_WINDOW_SIZE to the next char boundary
+                let mut end = TOPIC_WINDOW_SIZE;
+                while !text_lower.is_char_boundary(end) && end < text_lower.len() {
+                    end += 1;
+                }
+                end
+            };
             SearchableConversation {
                 text_lower,
                 full_text,
+                topic_end,
                 index: idx,
             }
         })
@@ -75,6 +97,7 @@ pub fn search(
             .filter_map(|s| {
                 let score = score_text(
                     &s.text_lower,
+                    s.topic_end,
                     &query_terms,
                     conversations[s.index].timestamp,
                     now,
@@ -92,6 +115,7 @@ pub fn search(
             .filter_map(|s| {
                 let score = score_text(
                     &s.text_lower,
+                    s.topic_end,
                     &query_terms,
                     conversations[s.index].timestamp,
                     now,
@@ -115,11 +139,27 @@ pub fn search(
     scored.into_iter().map(|(idx, _, _)| idx).collect()
 }
 
-/// Score a conversation based on substring matching and recency.
+/// Count non-overlapping occurrences of `needle` in `haystack`.
+fn count_occurrences(haystack: &str, needle: &str) -> usize {
+    if needle.is_empty() {
+        return 0;
+    }
+    haystack.matches(needle).count()
+}
+
+/// Score a conversation based on substring matching, term frequency density, and recency.
 /// Each query term (split on whitespace) must appear as a substring in the text (AND logic).
 /// This preserves URLs, paths, and other structured strings as single terms.
+///
+/// Scoring formula:
+///   For each term:
+///     weighted_count = topic_hits * TOPIC_WEIGHT + body_hits
+///     per-term score = sqrt(weighted_count)
+///   density = relevance / ln(text_length)
+///   final = density * recency_multiplier
 fn score_text(
     text_lower: &str,
+    topic_end: usize,
     query_terms: &[&str],
     timestamp: DateTime<Local>,
     now: DateTime<Local>,
@@ -128,14 +168,31 @@ fn score_text(
         return 0.0;
     }
 
-    // All terms must appear as substrings (AND logic)
+    let topic_window = &text_lower[..topic_end];
+    let body = &text_lower[topic_end..];
+
+    let mut relevance = 0.0;
     for &term in query_terms {
-        if !text_lower.contains(term) {
-            return 0.0;
+        let topic_hits = count_occurrences(topic_window, term);
+        let body_hits = count_occurrences(body, term);
+        let total_hits = topic_hits + body_hits;
+        if total_hits == 0 {
+            return 0.0; // AND logic: all terms must be present
         }
+        // Weight topic-window hits higher: early exchanges signal what the convo is about
+        let weighted = (topic_hits as f64) * TOPIC_WEIGHT + (body_hits as f64);
+        // sqrt dampens tool-output spam while preserving meaningful differences:
+        // 1 hit = 1.0, 5 hits ≈ 2.2, 20 hits ≈ 4.5, 100 hits = 10.0
+        relevance += weighted.sqrt();
     }
 
-    (query_terms.len() as f64) * recency_multiplier(timestamp, now)
+    // Normalize by text length so dense matches in short conversations rank higher.
+    // Use ln(len) to soften the penalty — a conversation twice as long isn't half as relevant.
+    // Floor at ln(500) ≈ 6.2 so very short texts don't get an outsized boost.
+    let len_norm = (text_lower.len().max(500) as f64).ln();
+    let density = relevance / len_norm;
+
+    density * recency_multiplier(timestamp, now)
 }
 
 /// Calculate recency multiplier based on age
@@ -308,5 +365,85 @@ mod tests {
         // Only the conversation with the exact URL should match
         assert_eq!(results.len(), 1);
         assert_eq!(results[0], 0);
+    }
+
+    #[test]
+    fn dense_match_ranks_higher_than_sparse() {
+        let now = Local::now();
+        // Same timestamp so recency doesn't influence ranking
+        let mut convs = vec![
+            // Sparse: "deploy" appears once in a long text
+            make_conv(
+                &format!("we need to deploy the app {}", "blah ".repeat(200)),
+                now,
+            ),
+            // Dense: "deploy" appears many times in a short text
+            make_conv(
+                "deploy deploy deploy the deploy fix for deploy",
+                now,
+            ),
+        ];
+        let searchable = precompute_search_text(&mut convs);
+        let results = search(&convs, &searchable, "deploy", now, None);
+        assert_eq!(results.len(), 2);
+        // Dense conversation should rank first
+        assert_eq!(results[0], 1, "dense match should rank higher than sparse");
+    }
+
+    #[test]
+    fn highly_relevant_old_convo_beats_barely_relevant_recent() {
+        let now = Local::now();
+        let padding = "unrelated stuff ".repeat(200); // push the mention past topic window
+        let mut convs = vec![
+            // Old but very relevant: "webpack" mentioned many times in topic window
+            make_conv(
+                "webpack config webpack loader webpack plugin webpack bundle webpack optimization",
+                now - Duration::days(60),
+            ),
+            // Recent but barely relevant: "webpack" mentioned once, buried past the topic window
+            make_conv(
+                &format!("{padding} someone mentioned webpack once"),
+                now,
+            ),
+        ];
+        let searchable = precompute_search_text(&mut convs);
+        let results = search(&convs, &searchable, "webpack", now, None);
+        assert_eq!(results.len(), 2);
+        // The highly relevant old conversation should beat the barely-relevant recent one
+        assert_eq!(results[0], 0, "highly relevant old convo should rank above barely relevant recent one");
+    }
+
+    #[test]
+    fn topic_window_match_ranks_higher_than_body_match() {
+        let now = Local::now();
+        // Build two conversations with the same total number of "migrate" hits,
+        // but one has hits in the topic window (first ~2000 chars) and the other in the body.
+        let padding = "x ".repeat(1500); // ~3000 chars of padding
+        let mut convs = vec![
+            // "migrate" only in the body (after the topic window)
+            make_conv(
+                &format!("{padding}migrate migrate migrate"),
+                now,
+            ),
+            // "migrate" in the topic window (beginning of conversation)
+            make_conv(
+                &format!("migrate migrate migrate {padding}"),
+                now,
+            ),
+        ];
+        let searchable = precompute_search_text(&mut convs);
+        let results = search(&convs, &searchable, "migrate", now, None);
+        assert_eq!(results.len(), 2);
+        // The conversation with topic-window hits should rank first
+        assert_eq!(results[0], 1, "topic-window match should rank higher than body-only match");
+    }
+
+    #[test]
+    fn count_occurrences_works() {
+        assert_eq!(count_occurrences("aaa", "a"), 3);
+        assert_eq!(count_occurrences("abcabc", "abc"), 2);
+        assert_eq!(count_occurrences("hello", "xyz"), 0);
+        assert_eq!(count_occurrences("", "a"), 0);
+        assert_eq!(count_occurrences("a", ""), 0);
     }
 }


### PR DESCRIPTION
## Summary
- Replace binary match scoring with term frequency density scoring so results are ranked by relevance, not just recency
- Weight matches in the first ~2000 chars of a conversation (the "topic window") 3x higher, since early exchanges establish what the conversation is about
- Use `sqrt(count)` for term frequency to dampen tool-output spam while preserving meaningful differences between "mentioned once" and "core topic"
- Normalize by `ln(text_length)` so dense matches in short conversations rank above sparse mentions in long ones

## Test plan
- [x] All 142 existing tests pass
- [x] Added 4 new tests: dense vs sparse ranking, old-relevant vs recent-irrelevant, topic window weighting, count_occurrences helper
- [x] No new clippy warnings
- [x] Manual testing: search for known conversation topics and verify the most relevant result surfaces first