### PR TITLE
Add exclude config to filter projects by name

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct ConfigFile {
     pub local: Option<bool>,
     pub display: Option<DisplayConfig>,
     pub resume: Option<ResumeConfig>,
+    pub exclude: Option<Vec<String>>,
 }
 
 #[derive(Deserialize, Debug, Default)]

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -23,9 +23,10 @@ use std::time::SystemTime;
 pub fn load_all_conversations(
     show_last: bool,
     debug_level: Option<DebugLevel>,
+    exclude_paths: &[String],
 ) -> Result<Vec<Conversation>> {
     let root = super::get_claude_projects_root()?;
-    let projects = list_projects(&root)?;
+    let projects = list_projects(&root, exclude_paths)?;
 
     debug::info(
         debug_level,
@@ -87,11 +88,12 @@ pub fn load_all_conversations(
 pub fn load_all_conversations_streaming(
     show_last: bool,
     debug_level: Option<DebugLevel>,
+    exclude_paths: Vec<String>,
 ) -> Receiver<LoaderMessage> {
     let (tx, rx) = mpsc::channel();
 
     thread::spawn(move || {
-        load_all_streaming_inner(tx, show_last, debug_level);
+        load_all_streaming_inner(tx, show_last, debug_level, &exclude_paths);
     });
 
     rx
@@ -101,6 +103,7 @@ fn load_all_streaming_inner(
     tx: Sender<LoaderMessage>,
     show_last: bool,
     debug_level: Option<DebugLevel>,
+    exclude_paths: &[String],
 ) {
     // First, validate that the projects root exists (fatal if not)
     let root = match super::get_claude_projects_root() {
@@ -119,7 +122,7 @@ fn load_all_streaming_inner(
     }
 
     // List projects (fatal if this fails)
-    let projects = match list_projects(&root) {
+    let projects = match list_projects(&root, exclude_paths) {
         Ok(p) => p,
         Err(e) => {
             let _ = tx.send(LoaderMessage::Fatal(e));
@@ -167,7 +170,7 @@ fn load_all_streaming_inner(
 }
 
 /// List all projects that contain conversation files
-pub fn list_projects(root: &Path) -> Result<Vec<Project>> {
+pub fn list_projects(root: &Path, exclude_names: &[String]) -> Result<Vec<Project>> {
     let entries = read_dir(root)?;
 
     let mut projects: Vec<Project> = entries
@@ -202,6 +205,15 @@ pub fn list_projects(root: &Path) -> Result<Vec<Project>> {
             // So / becomes -, but _ also becomes -, and __ becomes --
             // We convert single dashes to / but preserve double dashes as _
             let display_name = decode_project_dir_name(&name);
+
+            // Skip projects whose display name contains any exclude string
+            if exclude_names
+                .iter()
+                .any(|ex| display_name.contains(ex.as_str()))
+            {
+                return None;
+            }
+
             let modified = entry
                 .metadata()
                 .ok()?

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,8 +111,9 @@ fn run() -> Result<()> {
     let show_deleted_projects = args.show_deleted_projects || display_config.show_deleted_projects.unwrap_or(false);
 
     // Build provider registry
+    let exclude_paths = config.exclude.unwrap_or_default();
     let providers: Vec<Box<dyn Provider>> = vec![
-        Box::new(providers::claude::ClaudeProvider::new()),
+        Box::new(providers::claude::ClaudeProvider::new(exclude_paths)),
         Box::new(providers::cursor::CursorProvider::new()),
     ];
 

--- a/src/providers/claude.rs
+++ b/src/providers/claude.rs
@@ -7,12 +7,14 @@ use std::sync::mpsc::Receiver;
 
 pub struct ClaudeProvider {
     current_dir: Option<std::path::PathBuf>,
+    exclude_paths: Vec<String>,
 }
 
 impl ClaudeProvider {
-    pub fn new() -> Self {
+    pub fn new(exclude_paths: Vec<String>) -> Self {
         Self {
             current_dir: std::env::current_dir().ok(),
+            exclude_paths,
         }
     }
 }
@@ -56,7 +58,7 @@ impl super::Provider for ClaudeProvider {
         show_last: bool,
         debug: Option<crate::cli::DebugLevel>,
     ) -> Receiver<LoaderMessage> {
-        history::load_all_conversations_streaming(show_last, debug)
+        history::load_all_conversations_streaming(show_last, debug, self.exclude_paths.clone())
     }
 
     fn read_entries(&self, conversation: &Conversation) -> Result<Vec<LogEntry>> {


### PR DESCRIPTION
## Summary

- Adds an `exclude` option to `~/.config/mnemonai/config.toml` that accepts a list of strings
- Projects whose decoded display name contains any of the exclude strings are filtered out at discovery time, before conversations are parsed
- Example: `exclude = ["vision", "refainery"]` hides all projects with those names

## Test plan

- [x] All 145 existing tests pass
- [x] Add `exclude = ["<project>"]` to config and verify the project no longer appears in the TUI
- [x] Verify partial matches work (e.g. `"vis"` excludes `vision`)
- [x] Verify unrelated projects are not affected