### PR TITLE
Fix outdated config field name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ local = false
 exclude = ["some-project", "another-project"]
 
 [display]
-show_tools = false            # Show tool-use messages
+no_tools = false              # Hide tool-use messages
 relative_time = true          # "2 hours ago" vs "2026-02-18 14:30"
 last = false                  # Show last messages in preview (vs first)
 show_thinking = false         # Show thinking blocks


### PR DESCRIPTION
## Summary
- The README example config uses `show_tools` but the config struct expects `no_tools` (with inverted logic), causing a TOML parse error when users copy the example config.
- Updated `show_tools = false` → `no_tools = false` in the README example.

Fixes #4

## Test plan
- [ ] Copy the updated example config to `~/.config/mnemonai/config.toml`
- [ ] Run `mnemonai` and verify no parse error

🤖 Generated with [Claude Code](https://claude.com/claude-code)