### PR TITLE
Add Cursor Agent CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Universal AI coding conversation history browser. Search, browse, and resume con
 | Tool | History Format | Resume Support |
 |------|---------------|----------------|
 | **Claude Code** | JSONL files in `~/.claude/projects/` | `claude --resume <session-id>` |
-| **Cursor** | SQLite in workspace storage | Bridge extension + `cursor://` URI |
+| **Cursor Agent CLI** | JSONL transcripts in `~/.cursor/projects/*/agent-transcripts/` | `agent --resume <chat-id>` |
+| **Cursor (IDE)** | SQLite in workspace storage | Bridge extension + `cursor://` URI |
 
 ## Supported Platforms
 
@@ -102,7 +103,7 @@ pager = false                 # Use pager (less) for output
 show_deleted_projects = false # Include conversations from deleted directories
 
 [resume]
-default_args = []             # Default args passed to 'claude --resume'
+default_args = []             # Default args passed to 'claude --resume' for Claude Code sessions
 ```
 
 ## Releasing

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,11 +84,11 @@ pub struct Args {
     #[arg(long, group = "thinking_display")]
     pub hide_thinking: bool,
 
-    /// Resume the selected conversation in the Claude CLI
+    /// Resume the selected conversation in its original tool
     #[arg(
         long,
         short = 'c',
-        help = "Resume the selected conversation in Claude Code"
+        help = "Resume the selected conversation in its original tool"
     )]
     pub resume: bool,
 
@@ -123,10 +123,7 @@ pub struct Args {
     pub local: bool,
 
     /// Include conversations from deleted project directories
-    #[arg(
-        long,
-        help = "Include conversations from deleted project directories"
-    )]
+    #[arg(long, help = "Include conversations from deleted project directories")]
     pub show_deleted_projects: bool,
 
     /// Display output through a pager (less)

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -30,6 +30,7 @@ pub use path::{convert_path_to_project_dir_name, format_short_name_from_path};
 pub enum ProviderKind {
     Claude,
     Cursor,
+    CursorAgent,
 }
 
 /// Represents a JSONL parsing error with context for debugging
@@ -50,7 +51,7 @@ pub struct Conversation {
     pub index: usize,
     /// Which provider this conversation belongs to
     pub provider: ProviderKind,
-    /// Unique identifier (session UUID for Claude, composer ID for Cursor)
+    /// Unique identifier (session UUID for Claude, composer/chat ID for Cursor)
     pub id: String,
     pub timestamp: DateTime<Local>,
     pub preview: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,9 +19,9 @@ use error::{AppError, Result};
 use history::LoaderMessage;
 use providers::Provider;
 use std::io::IsTerminal;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{self, Receiver};
-use std::sync::Arc;
 
 fn main() {
     if let Err(e) = run() {
@@ -108,12 +108,14 @@ fn run() -> Result<()> {
         std::io::stdout().is_terminal(),
     );
     let use_global = !args.local && !config.local.unwrap_or(false);
-    let show_deleted_projects = args.show_deleted_projects || display_config.show_deleted_projects.unwrap_or(false);
+    let show_deleted_projects =
+        args.show_deleted_projects || display_config.show_deleted_projects.unwrap_or(false);
 
     // Build provider registry
     let exclude_paths = config.exclude.unwrap_or_default();
     let providers: Vec<Box<dyn Provider>> = vec![
         Box::new(providers::claude::ClaudeProvider::new(exclude_paths)),
+        Box::new(providers::cursor_agent::CursorAgentProvider::new()),
         Box::new(providers::cursor::CursorProvider::new()),
     ];
 
@@ -172,8 +174,14 @@ fn run() -> Result<()> {
             .collect();
         let rx = merge_streaming_loaders(receivers);
 
-        match tui::run_with_loader(rx, use_relative_time, tool_display, show_thinking, show_deleted_projects, &providers)?
-        {
+        match tui::run_with_loader(
+            rx,
+            use_relative_time,
+            tool_display,
+            show_thinking,
+            show_deleted_projects,
+            &providers,
+        )? {
             (tui::Action::Select(path), convs) => (convs, path),
             (tui::Action::Resume(path), convs) => {
                 resume_conversation(&convs, &path, &providers, default_args)?;
@@ -198,11 +206,8 @@ fn run() -> Result<()> {
                 Ok(mut convs) => {
                     // For non-Claude providers, filter to current directory
                     if provider.kind() != history::ProviderKind::Claude {
-                        convs.retain(|c| {
-                            c.project_path
-                                .as_ref()
-                                .is_some_and(|p| p == &current_dir)
-                        });
+                        convs
+                            .retain(|c| c.project_path.as_ref().is_some_and(|p| p == &current_dir));
                     }
                     conversations.extend(convs);
                 }
@@ -247,11 +252,7 @@ fn run() -> Result<()> {
         let conv = conversations.iter().find(|c| c.path == selected_path);
         let id = conv
             .map(|c| c.id.as_str())
-            .or_else(|| {
-                selected_path
-                    .file_stem()
-                    .and_then(|stem| stem.to_str())
-            })
+            .or_else(|| selected_path.file_stem().and_then(|stem| stem.to_str()))
             .ok_or_else(|| {
                 AppError::ClaudeExecutionError(
                     "Conversation filename is not valid Unicode".to_string(),

--- a/src/providers/cursor.rs
+++ b/src/providers/cursor.rs
@@ -56,9 +56,7 @@ struct ConvInfo {
 
 impl CursorProvider {
     pub fn new() -> Self {
-        let home = std::env::var("HOME")
-            .map(PathBuf::from)
-            .unwrap_or_default();
+        let home = std::env::var("HOME").map(PathBuf::from).unwrap_or_default();
         let cursor_user = home
             .join("Library")
             .join("Application Support")
@@ -179,8 +177,7 @@ impl CursorProvider {
     fn load_from_global_db(&self, show_last: bool) -> Result<Vec<Conversation>> {
         let conn = Connection::open_with_flags(
             &self.global_db_path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
-                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )?;
         let workspace_map = self.build_workspace_map();
         load_conversations_from_conn(&conn, show_last, &workspace_map, &self.global_db_path)
@@ -190,8 +187,7 @@ impl CursorProvider {
     fn load_bubbles(conv_id: &str, global_db_path: &Path) -> Result<Vec<Bubble>> {
         let conn = Connection::open_with_flags(
             global_db_path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY
-                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
         )?;
 
         let prefix = format!("bubbleId:{}:", conv_id);
@@ -413,10 +409,7 @@ fn query_full_text_for_conv(cursor_conn: &Connection, conv_id: &str) -> String {
 }
 
 /// Batch-insert full-text entries into the cache in a single transaction.
-fn save_full_text_to_cache(
-    cache_conn: &Connection,
-    entries: &[(String, String, usize)],
-) {
+fn save_full_text_to_cache(cache_conn: &Connection, entries: &[(String, String, usize)]) {
     if entries.is_empty() {
         return;
     }
@@ -475,10 +468,7 @@ fn build_full_text_map(
 }
 
 /// Batch-fetch bubble values by key using IN clauses.
-fn batch_fetch_bubbles(
-    conn: &Connection,
-    keys: &[String],
-) -> Result<HashMap<String, Value>> {
+fn batch_fetch_bubbles(conn: &Connection, keys: &[String]) -> Result<HashMap<String, Value>> {
     let mut bubble_map: HashMap<String, Value> = HashMap::with_capacity(keys.len());
     for chunk in keys.chunks(200) {
         let placeholders: Vec<&str> = chunk.iter().map(|_| "?").collect();
@@ -487,8 +477,10 @@ fn batch_fetch_bubbles(
             placeholders.join(",")
         );
         let mut stmt = conn.prepare(&sql)?;
-        let params: Vec<&dyn rusqlite::types::ToSql> =
-            chunk.iter().map(|k| k as &dyn rusqlite::types::ToSql).collect();
+        let params: Vec<&dyn rusqlite::types::ToSql> = chunk
+            .iter()
+            .map(|k| k as &dyn rusqlite::types::ToSql)
+            .collect();
         let rows = stmt.query_map(params.as_slice(), |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
         })?;
@@ -552,11 +544,17 @@ fn build_conversation(
 
     let model = bubble_map
         .get(&info.first_key)
-        .and_then(|v| v.get("modelType").and_then(|m| m.as_str()).map(String::from))
+        .and_then(|v| {
+            v.get("modelType")
+                .and_then(|m| m.as_str())
+                .map(String::from)
+        })
         .or_else(|| {
-            bubble_map
-                .get(&info.preview_key)
-                .and_then(|v| v.get("modelType").and_then(|m| m.as_str()).map(String::from))
+            bubble_map.get(&info.preview_key).and_then(|v| {
+                v.get("modelType")
+                    .and_then(|m| m.as_str())
+                    .map(String::from)
+            })
         });
 
     let ws_info = workspace_map.get(&info.conv_id);
@@ -705,7 +703,16 @@ fn load_conversations_from_conn_inner(
 
     let conversations: Vec<Conversation> = conv_infos
         .iter()
-        .filter_map(|info| build_conversation(info, &bubble_map, &index_timestamps, workspace_map, &full_text_map, db_path))
+        .filter_map(|info| {
+            build_conversation(
+                info,
+                &bubble_map,
+                &index_timestamps,
+                workspace_map,
+                &full_text_map,
+                db_path,
+            )
+        })
         .collect();
 
     Ok(conversations)
@@ -717,7 +724,7 @@ impl super::Provider for CursorProvider {
     }
 
     fn name(&self) -> &str {
-        "Cursor"
+        "Cursor (IDE)"
     }
 
     fn detect(&self) -> bool {
@@ -820,7 +827,14 @@ impl super::Provider for CursorProvider {
             let mut phase1_convs = Vec::new();
             let mut remaining_infos = Vec::new();
             for info in conv_infos {
-                if let Some(conv) = build_conversation(&info, &bubble_map, &index_timestamps, &workspace_map, &full_text_map, &global_db_path) {
+                if let Some(conv) = build_conversation(
+                    &info,
+                    &bubble_map,
+                    &index_timestamps,
+                    &workspace_map,
+                    &full_text_map,
+                    &global_db_path,
+                ) {
                     phase1_convs.push(conv);
                 } else {
                     remaining_infos.push(info);
@@ -868,7 +882,16 @@ impl super::Provider for CursorProvider {
 
                 let phase2_convs: Vec<Conversation> = remaining_infos
                     .iter()
-                    .filter_map(|info| build_conversation(info, &full_map, &index_timestamps, &workspace_map, &full_text_map, &global_db_path))
+                    .filter_map(|info| {
+                        build_conversation(
+                            info,
+                            &full_map,
+                            &index_timestamps,
+                            &workspace_map,
+                            &full_text_map,
+                            &global_db_path,
+                        )
+                    })
                     .collect();
 
                 if !phase2_convs.is_empty() {
@@ -914,17 +937,11 @@ impl super::Provider for CursorProvider {
         }
 
         // Open the conversation via URI (routes to the focused window)
-        let uri = format!(
-            "cursor://{}/open?id={}",
-            EXTENSION_ID, conversation.id
-        );
+        let uri = format!("cursor://{}/open?id={}", EXTENSION_ID, conversation.id);
 
-        Command::new("open")
-            .arg(&uri)
-            .status()
-            .map_err(|e| {
-                AppError::ClaudeExecutionError(format!("Failed to open Cursor URI: {}", e))
-            })?;
+        Command::new("open").arg(&uri).status().map_err(|e| {
+            AppError::ClaudeExecutionError(format!("Failed to open Cursor URI: {}", e))
+        })?;
 
         Ok(())
     }
@@ -932,9 +949,9 @@ impl super::Provider for CursorProvider {
     fn delete(&self, conversation: &Conversation) -> Result<()> {
         let conn = Connection::open_with_flags(
             &self.global_db_path,
-            rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
-                | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
-        ).map_err(|e| {
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )
+        .map_err(|e| {
             AppError::ClaudeExecutionError(format!(
                 "Failed to open Cursor database for writing: {}",
                 e
@@ -1028,17 +1045,15 @@ fn parse_bubble(json_str: &str) -> Option<Bubble> {
         .unwrap_or("")
         .to_string();
 
-    let rich_text = v
-        .get("richText")
-        .and_then(|r| {
-            if r.is_string() {
-                r.as_str().map(String::from)
-            } else if r.is_object() {
-                Some(r.to_string())
-            } else {
-                None
-            }
-        });
+    let rich_text = v.get("richText").and_then(|r| {
+        if r.is_string() {
+            r.as_str().map(String::from)
+        } else if r.is_object() {
+            Some(r.to_string())
+        } else {
+            None
+        }
+    });
 
     let created_at = v
         .get("createdAt")
@@ -1069,30 +1084,37 @@ fn parse_bubble(json_str: &str) -> Option<Bubble> {
         .and_then(|t| t.get("name"))
         .and_then(|n| n.as_str())
         .map(String::from);
-    let tool_args = tool_former
-        .and_then(|t| {
-            // Try rawArgs first, fall back to params (newer Cursor format)
-            let raw = t.get("rawArgs").and_then(|a| {
-                if let Some(s) = a.as_str() {
-                    if s.is_empty() { None } else { Some(s.to_string()) }
-                } else if a.is_object() || a.is_array() {
-                    Some(a.to_string())
+    let tool_args = tool_former.and_then(|t| {
+        // Try rawArgs first, fall back to params (newer Cursor format)
+        let raw = t.get("rawArgs").and_then(|a| {
+            if let Some(s) = a.as_str() {
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(s.to_string())
+                }
+            } else if a.is_object() || a.is_array() {
+                Some(a.to_string())
+            } else {
+                None
+            }
+        });
+        raw.or_else(|| {
+            t.get("params").and_then(|p| {
+                if let Some(s) = p.as_str() {
+                    if s.is_empty() {
+                        None
+                    } else {
+                        Some(s.to_string())
+                    }
+                } else if p.is_object() || p.is_array() {
+                    Some(p.to_string())
                 } else {
                     None
                 }
-            });
-            raw.or_else(|| {
-                t.get("params").and_then(|p| {
-                    if let Some(s) = p.as_str() {
-                        if s.is_empty() { None } else { Some(s.to_string()) }
-                    } else if p.is_object() || p.is_array() {
-                        Some(p.to_string())
-                    } else {
-                        None
-                    }
-                })
             })
-        });
+        })
+    });
     let tool_call_id = tool_former
         .and_then(|t| t.get("toolCallId"))
         .and_then(|i| i.as_str())
@@ -1321,9 +1343,7 @@ fn truncate_str(s: &str, max_bytes: usize) -> String {
 }
 
 fn is_extension_installed() -> bool {
-    let home = std::env::var("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_default();
+    let home = std::env::var("HOME").map(PathBuf::from).unwrap_or_default();
     let extensions_dir = home.join(".cursor").join("extensions");
     let ext_dir = extensions_dir.join("mnemonai.mnemonai-bridge-0.1.0");
 
@@ -1356,9 +1376,7 @@ fn is_extension_installed() -> bool {
 }
 
 fn install_extension() -> Result<()> {
-    let home = std::env::var("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_default();
+    let home = std::env::var("HOME").map(PathBuf::from).unwrap_or_default();
     let extensions_dir = home.join(".cursor").join("extensions");
     let ext_dir = extensions_dir.join("mnemonai.mnemonai-bridge-0.1.0");
 
@@ -1492,10 +1510,7 @@ mod tests {
         let entry = bubble_to_log_entry(&bubble).unwrap();
         match entry {
             crate::claude::LogEntry::User { message, .. } => {
-                assert_eq!(
-                    crate::claude::extract_text_from_user(&message),
-                    "Hello"
-                );
+                assert_eq!(crate::claude::extract_text_from_user(&message), "Hello");
             }
             _ => panic!("Expected User entry"),
         }
@@ -1567,7 +1582,10 @@ mod tests {
 
         let with_project = convs.iter().filter(|c| c.project_name.is_some()).count();
         let with_summary = convs.iter().filter(|c| c.summary.is_some()).count();
-        eprintln!("{} have project names, {} have titles", with_project, with_summary);
+        eprintln!(
+            "{} have project names, {} have titles",
+            with_project, with_summary
+        );
 
         for conv in convs.iter().take(3) {
             eprintln!(
@@ -1666,8 +1684,7 @@ mod tests {
 
         let ws_map = HashMap::new();
         let db_path = PathBuf::from("/tmp/test.vscdb");
-        let convs =
-            load_conversations_from_conn(&conn, false, &ws_map, &db_path).unwrap();
+        let convs = load_conversations_from_conn(&conn, false, &ws_map, &db_path).unwrap();
 
         assert_eq!(convs.len(), 1, "Should discover the conversation");
         assert_eq!(convs[0].preview, "How do I fix this bug?");
@@ -1703,8 +1720,7 @@ mod tests {
 
         let ws_map = HashMap::new();
         let db_path = PathBuf::from("/tmp/test.vscdb");
-        let convs =
-            load_conversations_from_conn(&conn, false, &ws_map, &db_path).unwrap();
+        let convs = load_conversations_from_conn(&conn, false, &ws_map, &db_path).unwrap();
 
         assert_eq!(convs.len(), 1);
         assert_eq!(convs[0].preview, "Hello world");
@@ -1740,10 +1756,13 @@ mod tests {
 
         let ws_map = HashMap::new();
         let db_path = PathBuf::from("/tmp/test.vscdb");
-        let convs =
-            load_conversations_from_conn(&conn, false, &ws_map, &db_path).unwrap();
+        let convs = load_conversations_from_conn(&conn, false, &ws_map, &db_path).unwrap();
 
-        assert_eq!(convs.len(), 0, "Should skip conversation with no user bubbles");
+        assert_eq!(
+            convs.len(),
+            0,
+            "Should skip conversation with no user bubbles"
+        );
     }
 
     #[test]
@@ -1787,12 +1806,10 @@ mod tests {
         let ws_map = HashMap::new();
         let db_path = PathBuf::from("/tmp/test.vscdb");
 
-        let convs_first =
-            load_conversations_from_conn(&conn, false, &ws_map, &db_path).unwrap();
+        let convs_first = load_conversations_from_conn(&conn, false, &ws_map, &db_path).unwrap();
         assert_eq!(convs_first[0].preview, "First question");
 
-        let convs_last =
-            load_conversations_from_conn(&conn, true, &ws_map, &db_path).unwrap();
+        let convs_last = load_conversations_from_conn(&conn, true, &ws_map, &db_path).unwrap();
         assert_eq!(convs_last[0].preview, "Follow-up question");
     }
 
@@ -1818,8 +1835,7 @@ mod tests {
 
         let ws_map = HashMap::new();
         let db_path = PathBuf::from("/tmp/test.vscdb");
-        let convs =
-            load_conversations_from_conn(&conn, false, &ws_map, &db_path).unwrap();
+        let convs = load_conversations_from_conn(&conn, false, &ws_map, &db_path).unwrap();
 
         assert_eq!(convs.len(), 1);
         assert_eq!(convs[0].preview, "Rich text content");
@@ -1881,8 +1897,7 @@ mod tests {
 
         let ws_map = HashMap::new();
         let db_path = PathBuf::from("/tmp/test.vscdb");
-        let convs =
-            load_conversations_from_conn(&conn, false, &ws_map, &db_path).unwrap();
+        let convs = load_conversations_from_conn(&conn, false, &ws_map, &db_path).unwrap();
 
         assert_eq!(convs.len(), 2, "Should discover 2 of 3 conversations");
         let ids: Vec<&str> = convs.iter().map(|c| c.id.as_str()).collect();
@@ -1923,8 +1938,7 @@ mod tests {
 
         let ws_map = HashMap::new();
         let db_path = PathBuf::from("/tmp/test.vscdb");
-        let convs =
-            load_conversations_from_conn(&conn, false, &ws_map, &db_path).unwrap();
+        let convs = load_conversations_from_conn(&conn, false, &ws_map, &db_path).unwrap();
 
         assert_eq!(convs.len(), 1);
         // The timestamp should come from the first_key (assistant at 10:00:00Z),
@@ -1981,14 +1995,8 @@ mod tests {
         );
 
         let (min_key, max_key) = query_user_key_for_conv(&conn, conv);
-        assert_eq!(
-            min_key,
-            Some(format!("bubbleId:{}:11111111-user1", conv))
-        );
-        assert_eq!(
-            max_key,
-            Some(format!("bubbleId:{}:eeeeeeee-user2", conv))
-        );
+        assert_eq!(min_key, Some(format!("bubbleId:{}:11111111-user1", conv)));
+        assert_eq!(max_key, Some(format!("bubbleId:{}:eeeeeeee-user2", conv)));
     }
 
     #[test]
@@ -2092,10 +2100,9 @@ mod tests {
         let db_path = PathBuf::from("/tmp/test.vscdb");
 
         // First call: populates cache
-        let convs = load_conversations_from_conn_inner(
-            &conn, false, &ws_map, &db_path, Some(&cache),
-        )
-        .unwrap();
+        let convs =
+            load_conversations_from_conn_inner(&conn, false, &ws_map, &db_path, Some(&cache))
+                .unwrap();
         assert_eq!(convs.len(), 1);
         assert_eq!(convs[0].preview, "My question");
 
@@ -2104,10 +2111,9 @@ mod tests {
         assert!(cached.contains_key(conv));
 
         // Second call: uses cache (same result)
-        let convs2 = load_conversations_from_conn_inner(
-            &conn, false, &ws_map, &db_path, Some(&cache),
-        )
-        .unwrap();
+        let convs2 =
+            load_conversations_from_conn_inner(&conn, false, &ws_map, &db_path, Some(&cache))
+                .unwrap();
         assert_eq!(convs2.len(), 1);
         assert_eq!(convs2[0].preview, "My question");
     }

--- a/src/providers/cursor_agent.rs
+++ b/src/providers/cursor_agent.rs
@@ -1,0 +1,828 @@
+use crate::claude::{
+    AssistantMessage, ContentBlock, LogEntry, UserContent, UserMessage, extract_text_from_blocks,
+};
+use crate::cli::DebugLevel;
+use crate::debug;
+use crate::error::{AppError, Result};
+use crate::history::{
+    Conversation, LoaderMessage, ParseError, ProviderKind, format_short_name_from_path,
+};
+use chrono::{DateTime, FixedOffset, Local};
+use rayon::prelude::*;
+use serde::Deserialize;
+use serde_json::Value;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::mpsc::{self, Receiver};
+use std::time::SystemTime;
+
+pub struct CursorAgentProvider {
+    projects_root: PathBuf,
+}
+
+struct AgentProject {
+    workspace_path: Option<PathBuf>,
+    transcript_files: Vec<PathBuf>,
+    modified: SystemTime,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CursorAgentTranscriptRecord {
+    role: String,
+    #[serde(default)]
+    timestamp: Option<String>,
+    #[serde(default)]
+    message: CursorAgentTranscriptMessage,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CursorAgentTranscriptMessage {
+    #[serde(default)]
+    content: Vec<CursorAgentTranscriptBlock>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CursorAgentTranscriptBlock {
+    #[serde(rename = "type")]
+    block_type: String,
+    #[serde(default)]
+    text: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    input: Option<Value>,
+    #[serde(default)]
+    thinking: Option<String>,
+    #[serde(default)]
+    signature: Option<String>,
+    #[serde(default)]
+    source: Option<Value>,
+    #[serde(default)]
+    content: Option<Value>,
+    #[serde(default)]
+    tool_use_id: Option<String>,
+    #[serde(default)]
+    id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkspaceTrusted {
+    #[serde(rename = "workspacePath")]
+    workspace_path: String,
+}
+
+struct ParsedTranscriptLine {
+    entry: LogEntry,
+    text_for_search: Option<String>,
+    text_for_preview: Option<String>,
+    timestamp: Option<DateTime<FixedOffset>>,
+    counts_as_message: bool,
+}
+
+impl CursorAgentProvider {
+    pub fn new() -> Self {
+        let home = std::env::var("HOME").map(PathBuf::from).unwrap_or_default();
+        Self {
+            projects_root: home.join(".cursor").join("projects"),
+        }
+    }
+
+    fn list_projects(&self) -> Result<Vec<AgentProject>> {
+        if !self.projects_root.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut projects = Vec::new();
+        for entry in fs::read_dir(&self.projects_root)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            let transcripts_dir = path.join("agent-transcripts");
+            if !transcripts_dir.is_dir() {
+                continue;
+            }
+
+            let transcript_files = collect_transcript_files(&transcripts_dir);
+            if transcript_files.is_empty() {
+                continue;
+            }
+
+            let modified = transcript_files
+                .iter()
+                .filter_map(|path| file_modified_time(path))
+                .max()
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+
+            projects.push(AgentProject {
+                workspace_path: load_workspace_path(&path),
+                transcript_files,
+                modified,
+            });
+        }
+
+        projects.sort_by(|a, b| b.modified.cmp(&a.modified));
+        Ok(projects)
+    }
+
+    fn load_project_conversations(
+        &self,
+        project: &AgentProject,
+        show_last: bool,
+        debug_level: Option<DebugLevel>,
+    ) -> Vec<Conversation> {
+        let workspace_path = project.workspace_path.clone();
+        let mut conversations: Vec<Conversation> = project
+            .transcript_files
+            .par_iter()
+            .filter_map(|path| {
+                let filename = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+
+                match process_transcript_file(
+                    path.clone(),
+                    show_last,
+                    workspace_path.clone(),
+                    debug_level,
+                ) {
+                    Ok(Some(conversation)) => {
+                        debug::debug(
+                            debug_level,
+                            &format!(
+                                "Loaded Cursor Agent transcript {}: {}",
+                                filename, conversation.preview
+                            ),
+                        );
+                        Some(conversation)
+                    }
+                    Ok(None) => None,
+                    Err(err) => {
+                        debug::warn(
+                            debug_level,
+                            &format!(
+                                "Failed to process Cursor Agent transcript {}: {}",
+                                filename, err
+                            ),
+                        );
+                        None
+                    }
+                }
+            })
+            .collect();
+
+        conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        for (idx, conversation) in conversations.iter_mut().enumerate() {
+            conversation.index = idx;
+        }
+        conversations
+    }
+}
+
+impl super::Provider for CursorAgentProvider {
+    fn kind(&self) -> ProviderKind {
+        ProviderKind::CursorAgent
+    }
+
+    fn name(&self) -> &str {
+        "Cursor Agent CLI"
+    }
+
+    fn detect(&self) -> bool {
+        self.projects_root.exists()
+    }
+
+    fn load_conversations(
+        &self,
+        show_last: bool,
+        debug_level: Option<DebugLevel>,
+    ) -> Result<Vec<Conversation>> {
+        let projects = self.list_projects()?;
+        if projects.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut conversations: Vec<Conversation> = projects
+            .iter()
+            .flat_map(|project| self.load_project_conversations(project, show_last, debug_level))
+            .collect();
+
+        conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        for (idx, conversation) in conversations.iter_mut().enumerate() {
+            conversation.index = idx;
+        }
+
+        Ok(conversations)
+    }
+
+    fn load_conversations_streaming(
+        &self,
+        show_last: bool,
+        debug_level: Option<DebugLevel>,
+    ) -> Receiver<LoaderMessage> {
+        let (tx, rx) = mpsc::channel();
+        let projects_root = self.projects_root.clone();
+
+        std::thread::spawn(move || {
+            let provider = CursorAgentProvider { projects_root };
+            let projects = match provider.list_projects() {
+                Ok(projects) => projects,
+                Err(_) => {
+                    let _ = tx.send(LoaderMessage::Done);
+                    return;
+                }
+            };
+
+            for project in &projects {
+                let conversations =
+                    provider.load_project_conversations(project, show_last, debug_level);
+                if !conversations.is_empty() {
+                    let _ = tx.send(LoaderMessage::Batch(conversations));
+                }
+            }
+
+            let _ = tx.send(LoaderMessage::Done);
+        });
+
+        rx
+    }
+
+    fn read_entries(&self, conversation: &Conversation) -> Result<Vec<LogEntry>> {
+        let file = File::open(&conversation.path)?;
+        let reader = BufReader::new(file);
+        let workspace_path = conversation.project_path.as_deref();
+        let mut entries = Vec::new();
+
+        for (line_idx, line_result) in reader.lines().enumerate() {
+            let line = line_result?;
+            if line.trim().is_empty() {
+                continue;
+            }
+
+            match parse_transcript_line(&line, line_idx + 1, workspace_path) {
+                Ok(Some(parsed)) => entries.push(parsed.entry),
+                Ok(None) => {}
+                Err(err) => {
+                    return Err(AppError::ClaudeExecutionError(format!(
+                        "Failed to parse Cursor Agent transcript {} line {}: {}",
+                        conversation.path.display(),
+                        line_idx + 1,
+                        err
+                    )));
+                }
+            }
+        }
+
+        Ok(entries)
+    }
+
+    fn resume(&self, conversation: &Conversation, _default_args: &[String]) -> Result<()> {
+        let workspace_path = conversation
+            .project_path
+            .as_ref()
+            .or(conversation.cwd.as_ref())
+            .ok_or_else(|| {
+                AppError::ClaudeExecutionError(
+                    "Cannot determine workspace path for this Cursor Agent conversation"
+                        .to_string(),
+                )
+            })?;
+
+        if !workspace_path.exists() || !workspace_path.is_dir() {
+            return Err(AppError::ClaudeExecutionError(format!(
+                "Workspace path no longer exists: {}",
+                workspace_path.display()
+            )));
+        }
+
+        let mut command = build_resume_command(workspace_path, &conversation.id)?;
+        run_cursor_agent_command(&mut command)
+    }
+
+    fn delete(&self, conversation: &Conversation) -> Result<()> {
+        if let Some(transcript_dir) = transcript_parent_dir(&conversation.path, &conversation.id) {
+            if transcript_dir.exists() {
+                fs::remove_dir_all(transcript_dir)?;
+                return Ok(());
+            }
+        }
+
+        fs::remove_file(&conversation.path)?;
+        Ok(())
+    }
+}
+
+fn process_transcript_file(
+    path: PathBuf,
+    show_last: bool,
+    workspace_path: Option<PathBuf>,
+    debug_level: Option<DebugLevel>,
+) -> Result<Option<Conversation>> {
+    let file = File::open(&path)?;
+    let reader = BufReader::new(file);
+    let mut all_parts = Vec::new();
+    let mut preview_parts = Vec::new();
+    let mut message_count = 0;
+    let mut parse_errors = Vec::new();
+    let mut first_timestamp: Option<DateTime<FixedOffset>> = None;
+    let mut last_timestamp: Option<DateTime<FixedOffset>> = None;
+
+    for (line_idx, line_result) in reader.lines().enumerate() {
+        let line = match line_result {
+            Ok(line) => line,
+            Err(err) => {
+                parse_errors.push(ParseError {
+                    line_number: line_idx + 1,
+                    line_content: String::new(),
+                    error_message: err.to_string(),
+                    context_before: Vec::new(),
+                    context_after: Vec::new(),
+                });
+                continue;
+            }
+        };
+
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        match parse_transcript_line(&line, line_idx + 1, workspace_path.as_deref()) {
+            Ok(Some(parsed)) => {
+                if let Some(ts) = parsed.timestamp {
+                    if first_timestamp.is_none() {
+                        first_timestamp = Some(ts);
+                    }
+                    last_timestamp = Some(ts);
+                }
+
+                if let Some(text) = parsed.text_for_search {
+                    all_parts.push(text);
+                }
+                if let Some(text) = parsed.text_for_preview {
+                    preview_parts.push(text);
+                }
+                if parsed.counts_as_message {
+                    message_count += 1;
+                }
+            }
+            Ok(None) => {}
+            Err(err) => {
+                debug::warn(
+                    debug_level,
+                    &format!(
+                        "Cursor Agent parse error in {} at line {}: {}",
+                        path.display(),
+                        line_idx + 1,
+                        err
+                    ),
+                );
+                parse_errors.push(ParseError {
+                    line_number: line_idx + 1,
+                    line_content: line,
+                    error_message: err.to_string(),
+                    context_before: Vec::new(),
+                    context_after: Vec::new(),
+                });
+            }
+        }
+    }
+
+    if preview_parts.is_empty() {
+        return Ok(None);
+    }
+
+    let preview = if show_last {
+        preview_parts
+            .iter()
+            .rev()
+            .take(3)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(" ... ")
+    } else {
+        preview_parts
+            .iter()
+            .take(3)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(" ... ")
+    };
+
+    let preview = normalize_whitespace(&preview);
+    let full_text = normalize_whitespace(&all_parts.join(" "));
+    let timestamp = last_timestamp
+        .map(|ts| ts.with_timezone(&Local))
+        .or_else(|| file_modified_time(&path).map(DateTime::<Local>::from))
+        .unwrap_or_else(Local::now);
+    let duration_minutes = match (first_timestamp, last_timestamp) {
+        (Some(first), Some(last)) => {
+            let duration = last.signed_duration_since(first);
+            (duration.num_minutes() > 0).then_some(duration.num_minutes() as u64)
+        }
+        _ => None,
+    };
+    let id = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let project_name = workspace_path
+        .as_ref()
+        .map(|workspace| format_short_name_from_path(workspace));
+
+    Ok(Some(Conversation {
+        path,
+        index: 0,
+        provider: ProviderKind::CursorAgent,
+        id,
+        timestamp,
+        preview,
+        full_text,
+        project_name,
+        project_path: workspace_path.clone(),
+        cwd: workspace_path,
+        message_count,
+        parse_errors,
+        summary: None,
+        model: None,
+        total_tokens: 0,
+        duration_minutes,
+    }))
+}
+
+fn parse_transcript_line(
+    line: &str,
+    line_idx: usize,
+    workspace_path: Option<&Path>,
+) -> Result<Option<ParsedTranscriptLine>> {
+    let record: CursorAgentTranscriptRecord = serde_json::from_str(line)?;
+    let timestamp = record
+        .timestamp
+        .as_deref()
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok());
+    let timestamp_str = record.timestamp.unwrap_or_default();
+
+    let blocks: Vec<ContentBlock> = record
+        .message
+        .content
+        .iter()
+        .enumerate()
+        .filter_map(|(block_idx, block)| block_to_content_block(block, line_idx, block_idx))
+        .collect();
+
+    if blocks.is_empty() {
+        return Ok(None);
+    }
+
+    let text = normalize_whitespace(&extract_text_from_blocks(&blocks));
+    let summary = if text.is_empty() {
+        summarize_blocks_for_preview(&record.message.content)
+    } else {
+        Some(text.clone())
+    };
+    let role = record.role.to_lowercase();
+    let entry = match role.as_str() {
+        "user" => LogEntry::User {
+            message: UserMessage {
+                role: "user".to_string(),
+                content: UserContent::Blocks(blocks),
+            },
+            timestamp: timestamp_str,
+            uuid: None,
+            cwd: workspace_path.map(|path| path.to_string_lossy().to_string()),
+        },
+        "assistant" => LogEntry::Assistant {
+            message: AssistantMessage {
+                role: "assistant".to_string(),
+                content: blocks,
+                model: None,
+                usage: None,
+                id: None,
+            },
+            timestamp: timestamp_str,
+            uuid: None,
+        },
+        _ => return Ok(None),
+    };
+
+    Ok(Some(ParsedTranscriptLine {
+        entry,
+        text_for_search: summary.clone(),
+        text_for_preview: summary,
+        timestamp,
+        counts_as_message: true,
+    }))
+}
+
+fn block_to_content_block(
+    block: &CursorAgentTranscriptBlock,
+    line_idx: usize,
+    block_idx: usize,
+) -> Option<ContentBlock> {
+    match block.block_type.as_str() {
+        "text" => block
+            .text
+            .as_ref()
+            .map(|text| ContentBlock::Text { text: text.clone() }),
+        "tool_use" => Some(ContentBlock::ToolUse {
+            id: block
+                .id
+                .clone()
+                .unwrap_or_else(|| format!("cursor-agent-{}-{}", line_idx, block_idx)),
+            name: block.name.clone().unwrap_or_else(|| "tool".to_string()),
+            input: block.input.clone().unwrap_or(Value::Null),
+        }),
+        "tool_result" => Some(ContentBlock::ToolResult {
+            tool_use_id: block
+                .tool_use_id
+                .clone()
+                .unwrap_or_else(|| format!("cursor-agent-result-{}-{}", line_idx, block_idx)),
+            content: block.content.clone(),
+        }),
+        "thinking" => Some(ContentBlock::Thinking {
+            thinking: block.thinking.clone().unwrap_or_default(),
+            signature: block
+                .signature
+                .clone()
+                .unwrap_or_else(|| format!("cursor-agent-thinking-{}-{}", line_idx, block_idx)),
+        }),
+        "image" => block.source.as_ref().map(|source| ContentBlock::Image {
+            source: source.clone(),
+        }),
+        _ => None,
+    }
+}
+
+fn summarize_blocks_for_preview(blocks: &[CursorAgentTranscriptBlock]) -> Option<String> {
+    let summary = blocks
+        .iter()
+        .filter_map(|block| match block.block_type.as_str() {
+            "tool_use" => block.name.as_ref().map(|name| format!("Tool: {}", name)),
+            "thinking" => Some("Thinking".to_string()),
+            _ => None,
+        })
+        .take(3)
+        .collect::<Vec<_>>()
+        .join(" ... ");
+
+    (!summary.is_empty()).then_some(summary)
+}
+
+fn collect_transcript_files(transcripts_dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let entries = match fs::read_dir(transcripts_dir) {
+        Ok(entries) => entries,
+        Err(_) => return files,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_file() && path.extension().is_some_and(|ext| ext == "jsonl") {
+            files.push(path);
+            continue;
+        }
+
+        if !path.is_dir() {
+            continue;
+        }
+
+        let default_path = path.join(format!("{}.jsonl", entry.file_name().to_string_lossy()));
+        if default_path.is_file() {
+            files.push(default_path);
+            continue;
+        }
+
+        let nested_entries = match fs::read_dir(&path) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        for nested in nested_entries.flatten() {
+            let nested_path = nested.path();
+            if nested_path.is_file() && nested_path.extension().is_some_and(|ext| ext == "jsonl") {
+                files.push(nested_path);
+                break;
+            }
+        }
+    }
+
+    files.sort_by_key(|path| file_modified_time(path).unwrap_or(SystemTime::UNIX_EPOCH));
+    files.reverse();
+    files
+}
+
+fn load_workspace_path(project_dir: &Path) -> Option<PathBuf> {
+    let trusted_path = project_dir.join(".workspace-trusted");
+    let content = fs::read_to_string(trusted_path).ok()?;
+    let trusted: WorkspaceTrusted = serde_json::from_str(&content).ok()?;
+    Some(PathBuf::from(trusted.workspace_path))
+}
+
+fn file_modified_time(path: &Path) -> Option<SystemTime> {
+    fs::metadata(path).ok()?.modified().ok()
+}
+
+fn transcript_parent_dir(path: &Path, conversation_id: &str) -> Option<PathBuf> {
+    let parent = path.parent()?;
+    let parent_name = parent.file_name()?.to_str()?;
+    let grandparent = parent.parent()?;
+    let grandparent_name = grandparent.file_name()?.to_str()?;
+    if parent_name == conversation_id && grandparent_name == "agent-transcripts" {
+        Some(parent.to_path_buf())
+    } else {
+        None
+    }
+}
+
+fn build_resume_command(workspace_path: &Path, chat_id: &str) -> Result<Command> {
+    let mut command = if command_exists("cursor-agent") {
+        Command::new("cursor-agent")
+    } else if command_exists("agent") {
+        Command::new("agent")
+    } else if command_exists("cursor") {
+        let mut command = Command::new("cursor");
+        command.arg("agent");
+        command
+    } else {
+        return Err(AppError::ClaudeExecutionError(
+            "Could not find a Cursor Agent CLI executable (`cursor-agent`, `agent`, or `cursor`)"
+                .to_string(),
+        ));
+    };
+
+    command
+        .arg("--resume")
+        .arg(chat_id)
+        .arg("--workspace")
+        .arg(workspace_path)
+        .current_dir(workspace_path);
+
+    Ok(command)
+}
+
+fn command_exists(name: &str) -> bool {
+    let Some(paths) = std::env::var_os("PATH") else {
+        return false;
+    };
+
+    std::env::split_paths(&paths).any(|dir| dir.join(name).is_file())
+}
+
+fn normalize_whitespace(input: &str) -> String {
+    input.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(unix)]
+fn run_cursor_agent_command(command: &mut Command) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+    let err = command.exec();
+    Err(AppError::ClaudeExecutionError(err.to_string()))
+}
+
+#[cfg(not(unix))]
+fn run_cursor_agent_command(command: &mut Command) -> Result<()> {
+    let status = command
+        .status()
+        .map_err(|err| AppError::ClaudeExecutionError(err.to_string()))?;
+
+    if !status.success() {
+        return Err(AppError::ClaudeExecutionError(format!(
+            "Cursor Agent CLI exited with status {}",
+            status
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::providers::Provider;
+    use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    struct TestTempDir {
+        path: PathBuf,
+    }
+
+    impl TestTempDir {
+        fn new(name: &str) -> Self {
+            let unique = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "mnemonai-cursor-agent-{}-{}-{}",
+                name,
+                std::process::id(),
+                unique
+            ));
+            fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+    }
+
+    impl Drop for TestTempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn parse_transcript_line_converts_tool_calls() {
+        let line = r#"{"role":"assistant","message":{"content":[{"type":"text","text":"Checking now"},{"type":"tool_use","name":"Shell","input":{"command":"git status"}}]}}"#;
+
+        let parsed = parse_transcript_line(line, 1, None).unwrap().unwrap();
+        match parsed.entry {
+            LogEntry::Assistant { message, .. } => {
+                assert_eq!(message.content.len(), 2);
+                match &message.content[1] {
+                    ContentBlock::ToolUse { id, name, input } => {
+                        assert_eq!(name, "Shell");
+                        assert!(!id.is_empty());
+                        assert_eq!(input["command"], "git status");
+                    }
+                    other => panic!("expected tool use, got {:?}", other),
+                }
+            }
+            other => panic!("expected assistant entry, got {:?}", other),
+        }
+        assert_eq!(parsed.text_for_preview.as_deref(), Some("Checking now"));
+    }
+
+    #[test]
+    fn process_transcript_file_builds_conversation_metadata() {
+        let temp = TestTempDir::new("conversation");
+        let workspace_path = temp.path.join("workspace");
+        fs::create_dir_all(&workspace_path).unwrap();
+
+        let transcript_path = temp.path.join("chat-123.jsonl");
+        let mut file = File::create(&transcript_path).unwrap();
+        writeln!(
+            file,
+            r#"{{"role":"user","timestamp":"2026-04-24T20:00:00Z","message":{{"content":[{{"type":"text","text":"hello from cursor agent"}}]}}}}"#
+        )
+        .unwrap();
+        writeln!(
+            file,
+            r#"{{"role":"assistant","timestamp":"2026-04-24T20:02:00Z","message":{{"content":[{{"type":"text","text":"hi there"}},{{"type":"tool_use","name":"Shell","input":{{"command":"pwd"}}}}]}}}}"#
+        )
+        .unwrap();
+
+        let conversation =
+            process_transcript_file(transcript_path, false, Some(workspace_path.clone()), None)
+                .unwrap()
+                .unwrap();
+
+        assert_eq!(conversation.provider, ProviderKind::CursorAgent);
+        assert_eq!(conversation.id, "chat-123");
+        assert_eq!(conversation.project_path.as_ref(), Some(&workspace_path));
+        assert_eq!(conversation.cwd.as_ref(), Some(&workspace_path));
+        assert_eq!(conversation.project_name.as_deref(), Some("workspace"));
+        assert!(conversation.preview.contains("hello from cursor agent"));
+        assert!(conversation.preview.contains("hi there"));
+        assert!(conversation.full_text.contains("hello from cursor agent"));
+        assert_eq!(conversation.message_count, 2);
+        assert_eq!(conversation.duration_minutes, Some(2));
+    }
+
+    #[test]
+    fn delete_prefers_transcript_directory() {
+        let temp = TestTempDir::new("delete");
+        let transcript_dir = temp.path.join("agent-transcripts").join("chat-123");
+        fs::create_dir_all(transcript_dir.join("subagents")).unwrap();
+        fs::write(transcript_dir.join("chat-123.jsonl"), "[]").unwrap();
+        fs::write(transcript_dir.join("subagents").join("worker.jsonl"), "[]").unwrap();
+
+        let provider = CursorAgentProvider {
+            projects_root: temp.path.clone(),
+        };
+        let conversation = Conversation {
+            path: transcript_dir.join("chat-123.jsonl"),
+            index: 0,
+            provider: ProviderKind::CursorAgent,
+            id: "chat-123".to_string(),
+            timestamp: Local::now(),
+            preview: String::new(),
+            full_text: String::new(),
+            project_name: None,
+            project_path: None,
+            cwd: None,
+            message_count: 0,
+            parse_errors: Vec::new(),
+            summary: None,
+            model: None,
+            total_tokens: 0,
+            duration_minutes: None,
+        };
+
+        provider.delete(&conversation).unwrap();
+        assert!(!transcript_dir.exists());
+    }
+}

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,5 +1,6 @@
 pub mod claude;
 pub mod cursor;
+pub mod cursor_agent;
 
 use crate::claude::LogEntry;
 use crate::error::Result;
@@ -13,10 +14,18 @@ pub trait Provider: Send + Sync {
     fn detect(&self) -> bool;
 
     /// Load conversations (synchronous, for single-project mode)
-    fn load_conversations(&self, show_last: bool, debug: Option<crate::cli::DebugLevel>) -> Result<Vec<Conversation>>;
+    fn load_conversations(
+        &self,
+        show_last: bool,
+        debug: Option<crate::cli::DebugLevel>,
+    ) -> Result<Vec<Conversation>>;
 
     /// Load conversations with streaming (for global mode)
-    fn load_conversations_streaming(&self, show_last: bool, debug: Option<crate::cli::DebugLevel>) -> Receiver<LoaderMessage>;
+    fn load_conversations_streaming(
+        &self,
+        show_last: bool,
+        debug: Option<crate::cli::DebugLevel>,
+    ) -> Receiver<LoaderMessage>;
 
     /// Read log entries for viewing/export (the core abstraction)
     fn read_entries(&self, conversation: &Conversation) -> Result<Vec<LogEntry>>;

--- a/src/tool_format.rs
+++ b/src/tool_format.rs
@@ -19,23 +19,36 @@ pub struct FormattedToolCall {
 pub fn format_tool_call(name: &str, input: &Value, max_width: usize) -> FormattedToolCall {
     match name {
         // Claude Code tools
-        "Task" => format_task(input),
-        "Bash" => format_bash(input, max_width),
-        "Read" => format_read(input),
+        "Task" | "Subagent" => format_task(input),
+        "Bash" | "Shell" => format_bash(input, max_width),
+        "Read" | "ReadFile" => format_read(input),
         "Grep" => format_grep(input),
         "Glob" => format_glob(input),
         "Edit" => format_edit(input),
         "Write" => format_write(input),
         "WebFetch" => format_web_fetch(input),
         "WebSearch" => format_web_search(input),
+        "ApplyPatch" => format_apply_patch(input),
+        "SemanticSearch" => format_cursor_search(input),
+        "Delete" => format_cursor_write(input),
         // Cursor tools — map to equivalent formatting
         "run_terminal_cmd" | "run_terminal_command_v2" => format_cursor_terminal(input, max_width),
         "read_file" | "read_file_v2" => format_cursor_read(input),
-        "edit_file" | "edit_file_v2" | "edit_file_v2_search_replace"
-        | "edit_file_v2_apply_based" | "edit_file_v2_write" | "search_replace"
-        | "apply_patch" | "MultiEdit" => format_cursor_edit(input),
-        "grep" | "grep_search" | "rg" | "ripgrep" | "ripgrep_raw_search"
-        | "codebase_search" | "semantic_search_full" => format_cursor_search(input),
+        "edit_file"
+        | "edit_file_v2"
+        | "edit_file_v2_search_replace"
+        | "edit_file_v2_apply_based"
+        | "edit_file_v2_write"
+        | "search_replace"
+        | "apply_patch"
+        | "MultiEdit" => format_cursor_edit(input),
+        "grep"
+        | "grep_search"
+        | "rg"
+        | "ripgrep"
+        | "ripgrep_raw_search"
+        | "codebase_search"
+        | "semantic_search_full" => format_cursor_search(input),
         "list_dir" | "list_dir_v2" | "glob_file_search" | "file_search" => {
             format_cursor_list(input)
         }
@@ -106,6 +119,7 @@ fn format_bash(input: &Value, max_width: usize) -> FormattedToolCall {
 fn format_read(input: &Value) -> FormattedToolCall {
     let file_path = input
         .get("file_path")
+        .or_else(|| input.get("path"))
         .and_then(|v| v.as_str())
         .unwrap_or("");
     let offset = input.get("offset").and_then(|v| v.as_u64());
@@ -139,8 +153,15 @@ fn format_grep(input: &Value) -> FormattedToolCall {
 }
 
 fn format_glob(input: &Value) -> FormattedToolCall {
-    let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
-    let path = input.get("path").and_then(|v| v.as_str());
+    let pattern = input
+        .get("pattern")
+        .or_else(|| input.get("glob_pattern"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let path = input
+        .get("path")
+        .or_else(|| input.get("target_directory"))
+        .and_then(|v| v.as_str());
 
     let header = match path {
         Some(p) => format!("Glob: {} in {}", pattern, p),
@@ -205,21 +226,34 @@ fn format_web_fetch(input: &Value) -> FormattedToolCall {
 }
 
 fn format_web_search(input: &Value) -> FormattedToolCall {
-    let query = input.get("query").and_then(|v| v.as_str()).unwrap_or("");
+    let query = input
+        .get("query")
+        .or_else(|| input.get("search_term"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let explanation = input.get("explanation").and_then(|v| v.as_str());
 
     FormattedToolCall {
         header: format!("Search: \"{}\"", query),
-        body: None,
+        body: explanation.map(|text| text.to_string()),
     }
+}
+
+fn format_apply_patch(input: &Value) -> FormattedToolCall {
+    if let Some(patch) = input.as_str() {
+        return FormattedToolCall {
+            header: "Patch".to_string(),
+            body: Some(patch.to_string()),
+        };
+    }
+
+    format_fallback("ApplyPatch", input)
 }
 
 // --- Cursor tool formatters ---
 
 fn format_cursor_terminal(input: &Value, max_width: usize) -> FormattedToolCall {
-    let command = input
-        .get("command")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
+    let command = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
     let prefix = "Bash: ";
     let prefix_len = prefix.len();
     let available_width = max_width.saturating_sub(prefix_len);
@@ -285,23 +319,35 @@ fn format_cursor_search(input: &Value) -> FormattedToolCall {
     let path = input
         .get("path")
         .or_else(|| input.get("directory"))
-        .and_then(|v| v.as_str());
+        .and_then(|v| v.as_str())
+        .map(|v| v.to_string())
+        .or_else(|| {
+            input
+                .get("target_directories")
+                .and_then(|v| v.as_array())
+                .map(|dirs| {
+                    dirs.iter()
+                        .filter_map(|dir| dir.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+                .filter(|dirs| !dirs.is_empty())
+        });
     let header = if let Some(p) = path {
         format!("Search: \"{}\" in {}", query, p)
     } else {
         format!("Search: \"{}\"", query)
     };
-    FormattedToolCall {
-        header,
-        body: None,
-    }
+    FormattedToolCall { header, body: None }
 }
 
 fn format_cursor_list(input: &Value) -> FormattedToolCall {
     let path = input
         .get("path")
         .or_else(|| input.get("directory"))
+        .or_else(|| input.get("target_directory"))
         .or_else(|| input.get("pattern"))
+        .or_else(|| input.get("glob_pattern"))
         .and_then(|v| v.as_str())
         .unwrap_or(".");
     FormattedToolCall {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -22,7 +22,8 @@ use std::time::Duration;
 fn provider_theme(kind: &ProviderKind) -> (String, (u8, u8, u8), (u8, u8, u8)) {
     match kind {
         ProviderKind::Claude => ("Claude".to_string(), (218, 119, 86), (170, 93, 67)),
-        ProviderKind::Cursor => ("Cursor".to_string(), (180, 130, 230), (140, 100, 180)),
+        ProviderKind::Cursor => ("Cursor IDE".to_string(), (180, 130, 230), (140, 100, 180)),
+        ProviderKind::CursorAgent => ("Cursor Agent".to_string(), (94, 184, 255), (72, 140, 194)),
     }
 }
 
@@ -182,9 +183,7 @@ impl App {
         show_deleted_projects: bool,
     ) -> Self {
         if !show_deleted_projects {
-            conversations.retain(|c| {
-                c.project_path.as_ref().map_or(true, |p| p.exists())
-            });
+            conversations.retain(|c| c.project_path.as_ref().map_or(true, |p| p.exists()));
         }
         let searchable = search::precompute_search_text(&mut conversations);
         let filtered: Vec<usize> = (0..conversations.len()).collect();
@@ -306,9 +305,7 @@ impl App {
     /// Note: Does NOT precompute search text - that's deferred to finish_loading.
     pub fn append_conversations(&mut self, mut new_convs: Vec<Conversation>) {
         if !self.show_deleted_projects {
-            new_convs.retain(|c| {
-                c.project_path.as_ref().map_or(true, |p| p.exists())
-            });
+            new_convs.retain(|c| c.project_path.as_ref().map_or(true, |p| p.exists()));
         }
         self.conversations.extend(new_convs);
 
@@ -387,14 +384,13 @@ impl App {
     fn update_filter(&mut self) {
         let now = Local::now();
         // When the new query extends the previous one, only rescore the already-filtered subset
-        let narrow_hint = if !self.previous_query.is_empty()
-            && self.query.starts_with(&self.previous_query)
-        {
-            // Move filtered out to avoid clone; search() will produce the new value
-            Some(std::mem::take(&mut self.filtered))
-        } else {
-            None
-        };
+        let narrow_hint =
+            if !self.previous_query.is_empty() && self.query.starts_with(&self.previous_query) {
+                // Move filtered out to avoid clone; search() will produce the new value
+                Some(std::mem::take(&mut self.filtered))
+            } else {
+                None
+            };
         self.filtered = search::search(
             &self.conversations,
             &self.searchable,
@@ -654,7 +650,11 @@ impl App {
     }
 
     /// Handle a key event during export/yank menu mode
-    fn handle_menu_key(&mut self, code: KeyCode, providers: &[Box<dyn Provider>]) -> Option<Action> {
+    fn handle_menu_key(
+        &mut self,
+        code: KeyCode,
+        providers: &[Box<dyn Provider>],
+    ) -> Option<Action> {
         let (selected, is_yank) = match &mut self.dialog_mode {
             DialogMode::ExportMenu { selected } => (selected, false),
             DialogMode::YankMenu { selected } => (selected, true),
@@ -742,8 +742,10 @@ impl App {
 
         let assistant_label = match conv.map(|c| &c.provider) {
             Some(ProviderKind::Cursor) => "Cursor",
+            Some(ProviderKind::CursorAgent) => "Cursor Agent",
             _ => "Claude",
-        }.to_string();
+        }
+        .to_string();
 
         let export_options = match &self.app_mode {
             AppMode::View(state) => crate::tui::export::ExportOptions {
@@ -759,8 +761,11 @@ impl App {
             // Use provider to read entries for export
             match provider.read_entries(conv) {
                 Ok(entries) => {
-                    let content =
-                        crate::tui::export::generate_content_from_entries(&entries, format, export_options);
+                    let content = crate::tui::export::generate_content_from_entries(
+                        &entries,
+                        format,
+                        export_options,
+                    );
                     if to_clipboard {
                         match arboard::Clipboard::new().and_then(|mut cb| cb.set_text(&content)) {
                             Ok(()) => crate::tui::export::ExportResult {
@@ -1348,11 +1353,7 @@ impl App {
     }
 
     /// Enter view mode for the currently selected conversation
-    pub fn enter_view_mode(
-        &mut self,
-        content_width: usize,
-        providers: &[Box<dyn Provider>],
-    ) {
+    pub fn enter_view_mode(&mut self, content_width: usize, providers: &[Box<dyn Provider>]) {
         use crate::tui::viewer::{RenderOptions, render_entries};
 
         let Some(selected) = self.selected else {
@@ -1519,11 +1520,7 @@ impl App {
     }
 
     /// Re-render the view with current toggle settings
-    fn re_render_view(
-        &mut self,
-        viewport_height: usize,
-        providers: &[Box<dyn Provider>],
-    ) {
+    fn re_render_view(&mut self, viewport_height: usize, providers: &[Box<dyn Provider>]) {
         use crate::tui::viewer::{RenderOptions, render_conversation, render_entries};
 
         if let AppMode::View(ref mut state) = self.app_mode {
@@ -1714,8 +1711,11 @@ pub fn run(
                     match action {
                         Action::Delete(ref path) => {
                             // Delete through provider dispatch
-                            let conv =
-                                app.conversations().iter().find(|c| &c.path == path).cloned();
+                            let conv = app
+                                .conversations()
+                                .iter()
+                                .find(|c| &c.path == path)
+                                .cloned();
                             let deleted = if let Some(ref conv) = conv {
                                 if let Some(provider) =
                                     providers.iter().find(|p| p.kind() == conv.provider)
@@ -1772,7 +1772,12 @@ pub fn run_with_loader(
     }));
 
     let mut guard = TerminalGuard::new()?;
-    let mut app = App::new_loading(use_relative_time, tool_display, show_thinking, show_deleted_projects);
+    let mut app = App::new_loading(
+        use_relative_time,
+        tool_display,
+        show_thinking,
+        show_deleted_projects,
+    );
 
     loop {
         // Process all pending loader messages (non-blocking)
@@ -1844,8 +1849,11 @@ pub fn run_with_loader(
                 match action {
                     Action::Delete(ref path) => {
                         // Delete through provider dispatch
-                        let conv =
-                            app.conversations().iter().find(|c| &c.path == path).cloned();
+                        let conv = app
+                            .conversations()
+                            .iter()
+                            .find(|c| &c.path == path)
+                            .cloned();
                         let deleted = if let Some(ref conv) = conv {
                             if let Some(provider) =
                                 providers.iter().find(|p| p.kind() == conv.provider)

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -91,17 +91,22 @@ fn format_tokens_long(tokens: u64) -> String {
 }
 
 /// Create a colored provider badge span
-fn provider_badge(provider: ProviderKind) -> Span<'static> {
+fn provider_badge_text(provider: ProviderKind) -> &'static str {
     match provider {
-        ProviderKind::Claude => Span::styled(
-            "[Claude] ",
-            Style::default().fg(Color::Rgb(218, 119, 86)), // Claude terracotta
-        ),
-        ProviderKind::Cursor => Span::styled(
-            "[Cursor] ",
-            Style::default().fg(Color::Rgb(180, 130, 230)), // Cursor purple
-        ),
+        ProviderKind::Claude => "[Claude] ",
+        ProviderKind::Cursor => "[Cursor] ",
+        ProviderKind::CursorAgent => "[Cursor CLI] ",
     }
+}
+
+fn provider_badge(provider: ProviderKind) -> Span<'static> {
+    let color = match provider {
+        ProviderKind::Claude => Color::Rgb(218, 119, 86), // Claude terracotta
+        ProviderKind::Cursor => Color::Rgb(180, 130, 230), // Cursor purple
+        ProviderKind::CursorAgent => Color::Rgb(94, 184, 255), // Cursor agent blue
+    };
+
+    Span::styled(provider_badge_text(provider), Style::default().fg(color))
 }
 
 /// Render the TUI
@@ -250,11 +255,7 @@ fn header_fits_single_line(conv: &crate::history::Conversation, terminal_width: 
         3 + formatted.len() // " · " + duration
     });
 
-    // Provider badge length: "[Claude] " = 10, "[Cursor] " = 10
-    let badge_len = match conv.provider {
-        ProviderKind::Claude => "[Claude] ".len(),
-        ProviderKind::Cursor => "[Cursor] ".len(),
-    };
+    let badge_len = provider_badge_text(conv.provider.clone()).len();
 
     // Format: "  [Provider] project · model · msg_count · duration · tokens · timestamp · summary"
     let total_len = 2
@@ -354,12 +355,16 @@ fn render_view_header(frame: &mut Frame, app: &App, state: &ViewState, area: Rec
             // Calculate header length to determine if long token format fits
             let model_len = model.as_ref().map(|m| m.len() + 3).unwrap_or(0); // + " · "
             let duration_len = duration.as_ref().map(|d| d.len() + 3).unwrap_or(0); // + " · "
-            let badge_len = match conv.provider {
-                ProviderKind::Claude => "[Claude] ".len(),
-                ProviderKind::Cursor => "[Cursor] ".len(),
-            };
-            let base_len =
-                2 + badge_len + project.len() + 3 + model_len + msg_count.len() + duration_len + 3 + 16; // 16 = timestamp
+            let badge_len = provider_badge_text(conv.provider.clone()).len();
+            let base_len = 2
+                + badge_len
+                + project.len()
+                + 3
+                + model_len
+                + msg_count.len()
+                + duration_len
+                + 3
+                + 16; // 16 = timestamp
 
             let tokens = if conv.total_tokens > 0 {
                 let long_form = format_tokens_long(conv.total_tokens);
@@ -1090,16 +1095,14 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect) {
             let right_len =
                 msg_count.chars().count() + duration_len + 3 + timestamp.chars().count(); // 3 for " · "
             let indicator_len = indicator.chars().count();
-            let badge_len = match conv.provider {
-                ProviderKind::Claude => "[Claude] ".chars().count(),
-                ProviderKind::Cursor => "[Cursor] ".chars().count(),
-            };
+            let badge_len = provider_badge_text(conv.provider.clone()).chars().count();
             let project_len = project_part.chars().count();
             let min_padding = 2; // Minimum padding between content and timestamp
 
             // Calculate available width for summary (filter empty summaries)
-            let available_for_summary =
-                width.saturating_sub(indicator_len + badge_len + project_len + right_len + min_padding + 4); // 4 for " · " prefix and ellipsis
+            let available_for_summary = width.saturating_sub(
+                indicator_len + badge_len + project_len + right_len + min_padding + 4,
+            ); // 4 for " · " prefix and ellipsis
 
             // Build summary part (dimmer, dynamically truncated based on available space)
             let summary_part = conv
@@ -1238,12 +1241,8 @@ fn render_list(frame: &mut Frame, app: &App, area: Rect) {
                     find_hidden_match(full_text, &truncated_preview, &query_words)
                 {
                     let context_width = width.saturating_sub(4); // Account for indicator
-                    let context_text = extract_match_context(
-                        full_text,
-                        match_pos,
-                        match_char_len,
-                        context_width,
-                    );
+                    let context_text =
+                        extract_match_context(full_text, match_pos, match_char_len, context_width);
 
                     // Truncate context if still too long
                     let truncated_context = if context_text.chars().count() > context_width {


### PR DESCRIPTION
## Summary
- add a dedicated Cursor Agent CLI provider that loads conversations from Cursor transcript storage and resumes them through the CLI
- distinguish Cursor Agent CLI from Cursor IDE in the TUI, provider metadata, and README so both histories can coexist cleanly
- extend tool-call formatting so Cursor Agent transcript tools render cleanly in the existing viewer/export pipeline

## Test plan
- [x] `cargo test`
- [x] Manually verify Cursor Agent CLI conversations load and resume successfully