### PR TITLE
Speed up warm history search

### DIFF
--- a/src/conversation_index.rs
+++ b/src/conversation_index.rs
@@ -12,7 +12,7 @@ use std::fs::Metadata;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const SCHEMA_VERSION: i64 = 1;
+const SCHEMA_VERSION: i64 = 2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SourceFingerprint {
@@ -81,10 +81,10 @@ where
                 schema_version, provider, show_last, source_path, source_mtime_millis,
                 source_size, id, timestamp, preview, full_text, search_text_lower,
                 search_topic_end, project_name, project_path, cwd, message_count,
-                summary, model, total_tokens, duration_minutes
+                parse_errors_json, summary, model, total_tokens, duration_minutes
             ) VALUES (
                 ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
-                ?15, ?16, ?17, ?18, ?19, ?20
+                ?15, ?16, ?17, ?18, ?19, ?20, ?21
             )",
         ) {
             Ok(stmt) => stmt,
@@ -101,6 +101,8 @@ where
             let topic_end = conversation
                 .search_topic_end
                 .unwrap_or_else(|| topic_end_for_text(text_lower));
+            let parse_errors_json = serde_json::to_string(&conversation.parse_errors)
+                .unwrap_or_else(|_| "[]".to_string());
 
             if stmt
                 .execute(params![
@@ -120,6 +122,7 @@ where
                     path_to_string(conversation.project_path.as_ref()),
                     path_to_string(conversation.cwd.as_ref()),
                     conversation.message_count as i64,
+                    parse_errors_json,
                     conversation.summary.as_deref(),
                     conversation.model.as_deref(),
                     conversation.total_tokens.min(i64::MAX as u64) as i64,
@@ -137,6 +140,17 @@ where
     let _ = tx.commit();
 }
 
+pub fn delete_conversation(provider: ProviderKind, path: &std::path::Path) {
+    let Some(conn) = open_index_db() else {
+        return;
+    };
+
+    let _ = conn.execute(
+        "DELETE FROM file_conversations WHERE provider = ?1 AND source_path = ?2",
+        params![provider_key(&provider), path.to_string_lossy()],
+    );
+}
+
 fn load_provider_cache_from_conn(
     conn: &Connection,
     provider: ProviderKind,
@@ -146,7 +160,8 @@ fn load_provider_cache_from_conn(
         "SELECT
             source_path, source_mtime_millis, source_size, id, timestamp, preview,
             full_text, search_text_lower, search_topic_end, project_name, project_path,
-            cwd, message_count, summary, model, total_tokens, duration_minutes
+            cwd, message_count, parse_errors_json, summary, model, total_tokens,
+            duration_minutes
          FROM file_conversations
          WHERE schema_version = ?1 AND provider = ?2 AND show_last = ?3",
     )?;
@@ -165,8 +180,10 @@ fn load_provider_cache_from_conn(
                 .unwrap_or_else(|_| Local::now());
             let search_topic_end: i64 = row.get(8)?;
             let message_count: i64 = row.get(12)?;
-            let total_tokens: i64 = row.get(15)?;
-            let duration_minutes: Option<i64> = row.get(16)?;
+            let parse_errors_json: String = row.get(13)?;
+            let parse_errors = serde_json::from_str(&parse_errors_json).unwrap_or_default();
+            let total_tokens: i64 = row.get(16)?;
+            let duration_minutes: Option<i64> = row.get(17)?;
 
             Ok((
                 PathBuf::from(&source_path),
@@ -189,9 +206,9 @@ fn load_provider_cache_from_conn(
                         project_path: optional_path(row.get(10)?),
                         cwd: optional_path(row.get(11)?),
                         message_count: message_count.max(0) as usize,
-                        parse_errors: Vec::new(),
-                        summary: row.get(13)?,
-                        model: row.get(14)?,
+                        parse_errors,
+                        summary: row.get(14)?,
+                        model: row.get(15)?,
                         total_tokens: total_tokens.max(0) as u64,
                         duration_minutes: duration_minutes.map(|v| v.max(0) as u64),
                     },
@@ -235,6 +252,7 @@ fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
              project_path          TEXT,
              cwd                   TEXT,
              message_count         INTEGER NOT NULL,
+             parse_errors_json     TEXT NOT NULL,
              summary               TEXT,
              model                 TEXT,
              total_tokens          INTEGER NOT NULL,
@@ -315,6 +333,13 @@ mod tests {
         let conn = Connection::open_in_memory().unwrap();
         init_schema(&conn).unwrap();
         let mut conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
+        conversation.parse_errors.push(crate::history::ParseError {
+            line_number: 7,
+            line_content: "{bad json".to_string(),
+            error_message: "expected value".to_string(),
+            context_before: vec!["before".to_string()],
+            context_after: vec!["after".to_string()],
+        });
         attach_search_cache(&mut conversation);
         let fingerprint = SourceFingerprint {
             modified_millis: 123,
@@ -334,6 +359,8 @@ mod tests {
         let loaded = cached.conversation_if_fresh(fingerprint).unwrap();
 
         assert_eq!(loaded.id, "session-1");
+        assert_eq!(loaded.parse_errors.len(), 1);
+        assert_eq!(loaded.parse_errors[0].line_number, 7);
         assert_eq!(
             loaded.search_text_lower.as_deref(),
             Some("hello cache body")
@@ -345,6 +372,46 @@ mod tests {
                     size: 456
                 })
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn delete_conversation_removes_cached_rows_for_all_preview_modes() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let mut conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
+        attach_search_cache(&mut conversation);
+        let fingerprint = SourceFingerprint {
+            modified_millis: 123,
+            size: 456,
+        };
+
+        save_conversations_to_conn(
+            &conn,
+            ProviderKind::Claude,
+            false,
+            [(&conversation, fingerprint)],
+        )
+        .unwrap();
+        save_conversations_to_conn(
+            &conn,
+            ProviderKind::Claude,
+            true,
+            [(&conversation, fingerprint)],
+        )
+        .unwrap();
+
+        delete_conversation_from_conn(&mut conn, ProviderKind::Claude, &conversation.path).unwrap();
+
+        assert!(
+            load_provider_cache_from_conn(&conn, ProviderKind::Claude, false)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            load_provider_cache_from_conn(&conn, ProviderKind::Claude, true)
+                .unwrap()
+                .is_empty()
         );
     }
 
@@ -362,14 +429,15 @@ mod tests {
                 schema_version, provider, show_last, source_path, source_mtime_millis,
                 source_size, id, timestamp, preview, full_text, search_text_lower,
                 search_topic_end, project_name, project_path, cwd, message_count,
-                summary, model, total_tokens, duration_minutes
+                parse_errors_json, summary, model, total_tokens, duration_minutes
             ) VALUES (
                 ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
-                ?15, ?16, ?17, ?18, ?19, ?20
+                ?15, ?16, ?17, ?18, ?19, ?20, ?21
             )",
         )?;
 
         for (conversation, fingerprint) in entries {
+            let parse_errors_json = serde_json::to_string(&conversation.parse_errors).unwrap();
             stmt.execute(params![
                 SCHEMA_VERSION,
                 provider_key(&provider),
@@ -387,6 +455,7 @@ mod tests {
                 path_to_string(conversation.project_path.as_ref()),
                 path_to_string(conversation.cwd.as_ref()),
                 conversation.message_count as i64,
+                parse_errors_json,
                 conversation.summary.as_deref(),
                 conversation.model.as_deref(),
                 conversation.total_tokens as i64,
@@ -394,6 +463,18 @@ mod tests {
             ])?;
         }
 
+        Ok(())
+    }
+
+    fn delete_conversation_from_conn(
+        conn: &mut Connection,
+        provider: ProviderKind,
+        path: &std::path::Path,
+    ) -> rusqlite::Result<()> {
+        conn.execute(
+            "DELETE FROM file_conversations WHERE provider = ?1 AND source_path = ?2",
+            params![provider_key(&provider), path.to_string_lossy()],
+        )?;
         Ok(())
     }
 }

--- a/src/conversation_index.rs
+++ b/src/conversation_index.rs
@@ -1,0 +1,399 @@
+//! Persistent conversation metadata and search-text index.
+//!
+//! File-backed providers use this sidecar database to skip reparsing unchanged
+//! JSONL transcripts and to reuse lowercased search text on warm starts.
+
+use crate::history::{Conversation, ProviderKind};
+use crate::tui::search::{normalize_for_search, topic_end_for_text};
+use chrono::{DateTime, Local};
+use rusqlite::{Connection, params};
+use std::collections::HashMap;
+use std::fs::Metadata;
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const SCHEMA_VERSION: i64 = 1;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SourceFingerprint {
+    pub modified_millis: i64,
+    pub size: i64,
+}
+
+#[derive(Clone)]
+pub struct CachedFileConversation {
+    fingerprint: SourceFingerprint,
+    conversation: Conversation,
+}
+
+impl CachedFileConversation {
+    pub fn conversation_if_fresh(&self, fingerprint: SourceFingerprint) -> Option<Conversation> {
+        (self.fingerprint == fingerprint).then(|| self.conversation.clone())
+    }
+}
+
+pub fn fingerprint_from_metadata(metadata: &Metadata) -> SourceFingerprint {
+    SourceFingerprint {
+        modified_millis: system_time_to_millis(metadata.modified().unwrap_or(UNIX_EPOCH)),
+        size: metadata.len().min(i64::MAX as u64) as i64,
+    }
+}
+
+pub fn attach_search_cache(conversation: &mut Conversation) {
+    if conversation.search_text_lower.is_none() {
+        conversation.search_text_lower = Some(normalize_for_search(&conversation.full_text));
+    }
+
+    if conversation.search_topic_end.is_none()
+        && let Some(text_lower) = &conversation.search_text_lower
+    {
+        conversation.search_topic_end = Some(topic_end_for_text(text_lower));
+    }
+}
+
+pub fn load_provider_cache(
+    provider: ProviderKind,
+    show_last: bool,
+) -> HashMap<PathBuf, CachedFileConversation> {
+    let Some(conn) = open_index_db() else {
+        return HashMap::new();
+    };
+
+    load_provider_cache_from_conn(&conn, provider, show_last).unwrap_or_default()
+}
+
+pub fn save_conversations<'a, I>(provider: ProviderKind, show_last: bool, entries: I)
+where
+    I: IntoIterator<Item = (&'a Conversation, SourceFingerprint)>,
+{
+    let Some(mut conn) = open_index_db() else {
+        return;
+    };
+
+    let tx = match conn.transaction() {
+        Ok(tx) => tx,
+        Err(_) => return,
+    };
+
+    {
+        let mut stmt = match tx.prepare(
+            "INSERT OR REPLACE INTO file_conversations (
+                schema_version, provider, show_last, source_path, source_mtime_millis,
+                source_size, id, timestamp, preview, full_text, search_text_lower,
+                search_topic_end, project_name, project_path, cwd, message_count,
+                summary, model, total_tokens, duration_minutes
+            ) VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                ?15, ?16, ?17, ?18, ?19, ?20
+            )",
+        ) {
+            Ok(stmt) => stmt,
+            Err(_) => return,
+        };
+
+        let provider_key = provider_key(&provider);
+        let show_last = i64::from(show_last);
+
+        for (conversation, fingerprint) in entries {
+            let Some(text_lower) = &conversation.search_text_lower else {
+                continue;
+            };
+            let topic_end = conversation
+                .search_topic_end
+                .unwrap_or_else(|| topic_end_for_text(text_lower));
+
+            if stmt
+                .execute(params![
+                    SCHEMA_VERSION,
+                    provider_key,
+                    show_last,
+                    conversation.path.to_string_lossy(),
+                    fingerprint.modified_millis,
+                    fingerprint.size,
+                    conversation.id,
+                    conversation.timestamp.to_rfc3339(),
+                    conversation.preview,
+                    conversation.full_text,
+                    text_lower,
+                    topic_end as i64,
+                    conversation.project_name.as_deref(),
+                    path_to_string(conversation.project_path.as_ref()),
+                    path_to_string(conversation.cwd.as_ref()),
+                    conversation.message_count as i64,
+                    conversation.summary.as_deref(),
+                    conversation.model.as_deref(),
+                    conversation.total_tokens.min(i64::MAX as u64) as i64,
+                    conversation
+                        .duration_minutes
+                        .map(|v| v.min(i64::MAX as u64) as i64),
+                ])
+                .is_err()
+            {
+                return;
+            }
+        }
+    }
+
+    let _ = tx.commit();
+}
+
+fn load_provider_cache_from_conn(
+    conn: &Connection,
+    provider: ProviderKind,
+    show_last: bool,
+) -> rusqlite::Result<HashMap<PathBuf, CachedFileConversation>> {
+    let mut stmt = conn.prepare(
+        "SELECT
+            source_path, source_mtime_millis, source_size, id, timestamp, preview,
+            full_text, search_text_lower, search_topic_end, project_name, project_path,
+            cwd, message_count, summary, model, total_tokens, duration_minutes
+         FROM file_conversations
+         WHERE schema_version = ?1 AND provider = ?2 AND show_last = ?3",
+    )?;
+
+    let rows = stmt.query_map(
+        params![
+            SCHEMA_VERSION,
+            provider_key(&provider),
+            i64::from(show_last)
+        ],
+        |row| {
+            let source_path: String = row.get(0)?;
+            let timestamp: String = row.get(4)?;
+            let timestamp = DateTime::parse_from_rfc3339(&timestamp)
+                .map(|ts| ts.with_timezone(&Local))
+                .unwrap_or_else(|_| Local::now());
+            let search_topic_end: i64 = row.get(8)?;
+            let message_count: i64 = row.get(12)?;
+            let total_tokens: i64 = row.get(15)?;
+            let duration_minutes: Option<i64> = row.get(16)?;
+
+            Ok((
+                PathBuf::from(&source_path),
+                CachedFileConversation {
+                    fingerprint: SourceFingerprint {
+                        modified_millis: row.get(1)?,
+                        size: row.get(2)?,
+                    },
+                    conversation: Conversation {
+                        path: PathBuf::from(source_path),
+                        index: 0,
+                        provider: provider.clone(),
+                        id: row.get(3)?,
+                        timestamp,
+                        preview: row.get(5)?,
+                        full_text: row.get(6)?,
+                        search_text_lower: Some(row.get(7)?),
+                        search_topic_end: Some(search_topic_end.max(0) as usize),
+                        project_name: row.get(9)?,
+                        project_path: optional_path(row.get(10)?),
+                        cwd: optional_path(row.get(11)?),
+                        message_count: message_count.max(0) as usize,
+                        parse_errors: Vec::new(),
+                        summary: row.get(13)?,
+                        model: row.get(14)?,
+                        total_tokens: total_tokens.max(0) as u64,
+                        duration_minutes: duration_minutes.map(|v| v.max(0) as u64),
+                    },
+                },
+            ))
+        },
+    )?;
+
+    Ok(rows.filter_map(|row| row.ok()).collect())
+}
+
+fn open_index_db() -> Option<Connection> {
+    let home = std::env::var("HOME").ok()?;
+    let dir = PathBuf::from(home)
+        .join(".local")
+        .join("state")
+        .join("mnemonai");
+    std::fs::create_dir_all(&dir).ok()?;
+    let conn = Connection::open(dir.join("conversation_index.db")).ok()?;
+    init_schema(&conn).ok()?;
+    Some(conn)
+}
+
+fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute_batch(
+        "PRAGMA journal_mode=WAL;
+         CREATE TABLE IF NOT EXISTS file_conversations (
+             schema_version        INTEGER NOT NULL,
+             provider              TEXT NOT NULL,
+             show_last             INTEGER NOT NULL,
+             source_path           TEXT NOT NULL,
+             source_mtime_millis   INTEGER NOT NULL,
+             source_size           INTEGER NOT NULL,
+             id                    TEXT NOT NULL,
+             timestamp             TEXT NOT NULL,
+             preview               TEXT NOT NULL,
+             full_text             TEXT NOT NULL,
+             search_text_lower     TEXT NOT NULL,
+             search_topic_end      INTEGER NOT NULL,
+             project_name          TEXT,
+             project_path          TEXT,
+             cwd                   TEXT,
+             message_count         INTEGER NOT NULL,
+             summary               TEXT,
+             model                 TEXT,
+             total_tokens          INTEGER NOT NULL,
+             duration_minutes      INTEGER,
+             PRIMARY KEY (schema_version, provider, show_last, source_path)
+         );",
+    )
+}
+
+fn provider_key(provider: &ProviderKind) -> &'static str {
+    match provider {
+        ProviderKind::Claude => "claude",
+        ProviderKind::Cursor => "cursor",
+        ProviderKind::CursorAgent => "cursor-agent",
+    }
+}
+
+fn system_time_to_millis(time: SystemTime) -> i64 {
+    time.duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
+        .unwrap_or(0)
+}
+
+fn path_to_string(path: Option<&PathBuf>) -> Option<String> {
+    path.map(|path| path.to_string_lossy().to_string())
+}
+
+fn optional_path(path: Option<String>) -> Option<PathBuf> {
+    path.filter(|path| !path.is_empty()).map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Local;
+
+    fn make_conversation(path: PathBuf) -> Conversation {
+        Conversation {
+            path,
+            index: 0,
+            provider: ProviderKind::Claude,
+            id: "session-1".to_string(),
+            timestamp: Local::now(),
+            preview: "Hello Cache".to_string(),
+            full_text: "Hello Cache Body".to_string(),
+            project_name: Some("project".to_string()),
+            project_path: None,
+            cwd: None,
+            message_count: 1,
+            parse_errors: Vec::new(),
+            summary: None,
+            model: None,
+            total_tokens: 0,
+            duration_minutes: None,
+            search_text_lower: None,
+            search_topic_end: None,
+        }
+    }
+
+    #[test]
+    fn attach_search_cache_populates_lowercase_text() {
+        let mut conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
+
+        attach_search_cache(&mut conversation);
+
+        assert_eq!(
+            conversation.search_text_lower.as_deref(),
+            Some("hello cache body")
+        );
+        assert_eq!(
+            conversation.search_topic_end,
+            Some("hello cache body".len())
+        );
+    }
+
+    #[test]
+    fn load_cache_round_trips_conversation() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let mut conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
+        attach_search_cache(&mut conversation);
+        let fingerprint = SourceFingerprint {
+            modified_millis: 123,
+            size: 456,
+        };
+
+        save_conversations_to_conn(
+            &conn,
+            ProviderKind::Claude,
+            false,
+            [(&conversation, fingerprint)],
+        )
+        .unwrap();
+
+        let cache = load_provider_cache_from_conn(&conn, ProviderKind::Claude, false).unwrap();
+        let cached = cache.get(&conversation.path).unwrap();
+        let loaded = cached.conversation_if_fresh(fingerprint).unwrap();
+
+        assert_eq!(loaded.id, "session-1");
+        assert_eq!(
+            loaded.search_text_lower.as_deref(),
+            Some("hello cache body")
+        );
+        assert!(
+            cached
+                .conversation_if_fresh(SourceFingerprint {
+                    modified_millis: 999,
+                    size: 456
+                })
+                .is_none()
+        );
+    }
+
+    fn save_conversations_to_conn<'a, I>(
+        conn: &Connection,
+        provider: ProviderKind,
+        show_last: bool,
+        entries: I,
+    ) -> rusqlite::Result<()>
+    where
+        I: IntoIterator<Item = (&'a Conversation, SourceFingerprint)>,
+    {
+        let mut stmt = conn.prepare(
+            "INSERT OR REPLACE INTO file_conversations (
+                schema_version, provider, show_last, source_path, source_mtime_millis,
+                source_size, id, timestamp, preview, full_text, search_text_lower,
+                search_topic_end, project_name, project_path, cwd, message_count,
+                summary, model, total_tokens, duration_minutes
+            ) VALUES (
+                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                ?15, ?16, ?17, ?18, ?19, ?20
+            )",
+        )?;
+
+        for (conversation, fingerprint) in entries {
+            stmt.execute(params![
+                SCHEMA_VERSION,
+                provider_key(&provider),
+                i64::from(show_last),
+                conversation.path.to_string_lossy(),
+                fingerprint.modified_millis,
+                fingerprint.size,
+                conversation.id,
+                conversation.timestamp.to_rfc3339(),
+                conversation.preview,
+                conversation.full_text,
+                conversation.search_text_lower.as_deref().unwrap(),
+                conversation.search_topic_end.unwrap() as i64,
+                conversation.project_name.as_deref(),
+                path_to_string(conversation.project_path.as_ref()),
+                path_to_string(conversation.cwd.as_ref()),
+                conversation.message_count as i64,
+                conversation.summary.as_deref(),
+                conversation.model.as_deref(),
+                conversation.total_tokens as i64,
+                conversation.duration_minutes.map(|v| v as i64),
+            ])?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -9,14 +9,33 @@ use super::path::{
 };
 use super::{Conversation, LoaderMessage, Project};
 use crate::cli::DebugLevel;
+use crate::conversation_index::{
+    CachedFileConversation, SourceFingerprint, attach_search_cache, fingerprint_from_metadata,
+    load_provider_cache, save_conversations,
+};
 use crate::debug;
 use crate::error::{AppError, Result};
+use crate::history::ProviderKind;
 use rayon::prelude::*;
+use std::collections::HashMap;
 use std::fs::read_dir;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 use std::time::SystemTime;
+
+enum ConversationLoad {
+    Cached(Conversation),
+    Fresh(Conversation, SourceFingerprint),
+}
+
+impl ConversationLoad {
+    fn into_conversation(self) -> Conversation {
+        match self {
+            Self::Cached(conversation) | Self::Fresh(conversation, _) => conversation,
+        }
+    }
+}
 
 /// Load conversations from ALL projects globally
 #[allow(dead_code)]
@@ -33,12 +52,14 @@ pub fn load_all_conversations(
         &format!("Loading global history from {} projects", projects.len()),
     );
 
+    let cache = load_provider_cache(ProviderKind::Claude, show_last);
+
     // Load conversations from all projects in parallel
     let mut all_conversations: Vec<Conversation> = projects
         .par_iter()
         .flat_map(|project| {
             let project_dir = root.join(&project.name);
-            match load_conversations(&project_dir, show_last, debug_level) {
+            match load_conversations_with_cache(&project_dir, show_last, debug_level, &cache) {
                 Ok(mut convs) => {
                     // Fallback path for old JSONL files without cwd field
                     let fallback_path = decode_project_dir_name_to_path(&project.name);
@@ -135,11 +156,13 @@ fn load_all_streaming_inner(
         &format!("Loading global history from {} projects", projects.len()),
     );
 
+    let cache = load_provider_cache(ProviderKind::Claude, show_last);
+
     // Process projects in parallel and send batches as they complete
     projects.par_iter().for_each(|project| {
         let project_dir = root.join(&project.name);
 
-        match load_conversations(&project_dir, show_last, debug_level) {
+        match load_conversations_with_cache(&project_dir, show_last, debug_level, &cache) {
             Ok(mut convs) => {
                 if convs.is_empty() {
                     return;
@@ -241,6 +264,16 @@ pub fn load_conversations(
     show_last: bool,
     debug_level: Option<DebugLevel>,
 ) -> Result<Vec<Conversation>> {
+    let cache = load_provider_cache(ProviderKind::Claude, show_last);
+    load_conversations_with_cache(projects_dir, show_last, debug_level, &cache)
+}
+
+fn load_conversations_with_cache(
+    projects_dir: &Path,
+    show_last: bool,
+    debug_level: Option<DebugLevel>,
+    cache: &HashMap<PathBuf, CachedFileConversation>,
+) -> Result<Vec<Conversation>> {
     // Find all JSONL files and capture metadata in one pass
     let mut files_with_meta = Vec::new();
     let mut skipped_agent_files = 0;
@@ -258,12 +291,13 @@ pub fn load_conversations(
                 continue;
             }
 
-            let modified = entry
-                .metadata()
-                .ok()
+            let metadata = entry.metadata().ok();
+            let modified = metadata
+                .as_ref()
                 .and_then(|metadata| metadata.modified().ok());
+            let fingerprint = metadata.as_ref().map(fingerprint_from_metadata);
 
-            files_with_meta.push((path, modified));
+            files_with_meta.push((path, modified, fingerprint));
         }
     }
 
@@ -277,26 +311,44 @@ pub fn load_conversations(
     );
 
     // Sort by modification time (newest first)
-    files_with_meta.sort_by_key(|(_, modified)| modified.unwrap_or(SystemTime::UNIX_EPOCH));
+    files_with_meta.sort_by_key(|(_, modified, _)| modified.unwrap_or(SystemTime::UNIX_EPOCH));
     files_with_meta.reverse();
 
     // Process each file (potentially in parallel)
-    let mut conversations: Vec<Conversation> = files_with_meta
+    let loaded: Vec<ConversationLoad> = files_with_meta
         .into_par_iter()
-        .filter_map(|(path, modified)| {
+        .filter_map(|(path, modified, fingerprint)| {
             let filename = path
                 .file_name()
                 .and_then(|f| f.to_str())
                 .unwrap_or("unknown")
                 .to_owned();
 
+            if let Some(fingerprint) = fingerprint
+                && let Some(conversation) = cache
+                    .get(&path)
+                    .and_then(|cached| cached.conversation_if_fresh(fingerprint))
+            {
+                debug::debug(
+                    debug_level,
+                    &format!("Loaded {} from conversation index", filename),
+                );
+                return Some(ConversationLoad::Cached(conversation));
+            }
+
             match process_conversation_file(path, show_last, modified, debug_level) {
-                Ok(Some(conversation)) => {
+                Ok(Some(mut conversation)) => {
                     debug::debug(
                         debug_level,
                         &format!("Loaded {}: {}", filename, conversation.preview),
                     );
-                    Some(conversation)
+                    attach_search_cache(&mut conversation);
+                    match fingerprint {
+                        Some(fingerprint) => {
+                            Some(ConversationLoad::Fresh(conversation, fingerprint))
+                        }
+                        None => Some(ConversationLoad::Cached(conversation)),
+                    }
                 }
                 Ok(None) => None,
                 Err(e) => {
@@ -308,6 +360,22 @@ pub fn load_conversations(
                 }
             }
         })
+        .collect();
+
+    save_conversations(
+        ProviderKind::Claude,
+        show_last,
+        loaded.iter().filter_map(|loaded| match loaded {
+            ConversationLoad::Fresh(conversation, fingerprint) => {
+                Some((conversation, *fingerprint))
+            }
+            ConversationLoad::Cached(_) => None,
+        }),
+    );
+
+    let mut conversations: Vec<Conversation> = loaded
+        .into_iter()
+        .map(ConversationLoad::into_conversation)
         .collect();
 
     // Ensure deterministic ordering after parallel processing

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -17,6 +17,7 @@ mod path;
 
 use crate::error::{AppError, Result};
 use chrono::{DateTime, Local};
+use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::SystemTime;
 
@@ -34,7 +35,7 @@ pub enum ProviderKind {
 }
 
 /// Represents a JSONL parsing error with context for debugging
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ParseError {
     pub line_number: usize,
     pub line_content: String,

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -72,6 +72,10 @@ pub struct Conversation {
     pub total_tokens: u64,
     /// Conversation duration in minutes (from first to last message)
     pub duration_minutes: Option<u64>,
+    /// Cached lowercased full text for search, when loaded from the persistent index.
+    pub search_text_lower: Option<String>,
+    /// Cached byte offset where the topic window ends in `search_text_lower`.
+    pub search_topic_end: Option<usize>,
 }
 
 pub struct Project {

--- a/src/history/parser.rs
+++ b/src/history/parser.rs
@@ -336,6 +336,8 @@ pub(crate) fn process_conversation_reader<R: BufRead>(
         model: extracted_model,
         total_tokens,
         duration_minutes,
+        search_text_lower: None,
+        search_topic_end: None,
     }))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod claude;
 mod cli;
 mod config;
+mod conversation_index;
 mod debug;
 mod debug_log;
 mod display;

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -558,17 +558,14 @@ mod tests {
     #[test]
     fn test_code_block() {
         let result = render_markdown("```rust\nlet x = 1;\n```", 80);
-        // With syntax highlighting, tokens are split with ANSI codes
         // Check individual tokens are present
         assert!(result.contains("let"));
         assert!(result.contains("x"));
         assert!(result.contains("1"));
         assert!(result.contains("```"));
-        // Verify syntax highlighting is applied (ANSI color codes present)
         assert!(
-            result.contains("\x1b[38;2;"),
-            "Expected syntax highlighting ANSI codes in: {:?}",
-            result
+            crate::syntax::highlight_code_tui("let x = 1;", "rust").is_some(),
+            "Expected Rust syntax to be available"
         );
     }
 

--- a/src/providers/claude.rs
+++ b/src/providers/claude.rs
@@ -1,4 +1,5 @@
 use crate::claude::LogEntry;
+use crate::conversation_index::delete_conversation;
 use crate::error::{AppError, Result};
 use crate::history::{self, Conversation, LoaderMessage, ProviderKind};
 use crate::tui::viewer;
@@ -90,7 +91,9 @@ impl super::Provider for ClaudeProvider {
     }
 
     fn delete(&self, conversation: &Conversation) -> Result<()> {
-        std::fs::remove_file(&conversation.path).map_err(AppError::Io)
+        std::fs::remove_file(&conversation.path).map_err(AppError::Io)?;
+        delete_conversation(ProviderKind::Claude, &conversation.path);
+        Ok(())
     }
 }
 

--- a/src/providers/cursor.rs
+++ b/src/providers/cursor.rs
@@ -617,6 +617,8 @@ fn build_conversation(
         model,
         total_tokens: 0,
         duration_minutes: None,
+        search_text_lower: None,
+        search_topic_end: None,
     })
 }
 

--- a/src/providers/cursor_agent.rs
+++ b/src/providers/cursor_agent.rs
@@ -2,6 +2,10 @@ use crate::claude::{
     AssistantMessage, ContentBlock, LogEntry, UserContent, UserMessage, extract_text_from_blocks,
 };
 use crate::cli::DebugLevel;
+use crate::conversation_index::{
+    CachedFileConversation, SourceFingerprint, attach_search_cache, fingerprint_from_metadata,
+    load_provider_cache, save_conversations,
+};
 use crate::debug;
 use crate::error::{AppError, Result};
 use crate::history::{
@@ -11,6 +15,7 @@ use chrono::{DateTime, FixedOffset, Local};
 use rayon::prelude::*;
 use serde::Deserialize;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -81,6 +86,19 @@ struct ParsedTranscriptLine {
     counts_as_message: bool,
 }
 
+enum ConversationLoad {
+    Cached(Conversation),
+    Fresh(Conversation, SourceFingerprint),
+}
+
+impl ConversationLoad {
+    fn into_conversation(self) -> Conversation {
+        match self {
+            Self::Cached(conversation) | Self::Fresh(conversation, _) => conversation,
+        }
+    }
+}
+
 impl CursorAgentProvider {
     pub fn new() -> Self {
         let home = std::env::var("HOME").map(PathBuf::from).unwrap_or_default();
@@ -134,9 +152,10 @@ impl CursorAgentProvider {
         project: &AgentProject,
         show_last: bool,
         debug_level: Option<DebugLevel>,
+        cache: &HashMap<PathBuf, CachedFileConversation>,
     ) -> Vec<Conversation> {
         let workspace_path = project.workspace_path.clone();
-        let mut conversations: Vec<Conversation> = project
+        let loaded: Vec<ConversationLoad> = project
             .transcript_files
             .par_iter()
             .filter_map(|path| {
@@ -145,6 +164,19 @@ impl CursorAgentProvider {
                     .and_then(|name| name.to_str())
                     .unwrap_or("unknown")
                     .to_string();
+                let fingerprint = file_fingerprint(path);
+
+                if let Some(fingerprint) = fingerprint
+                    && let Some(conversation) = cache
+                        .get(path)
+                        .and_then(|cached| cached.conversation_if_fresh(fingerprint))
+                {
+                    debug::debug(
+                        debug_level,
+                        &format!("Loaded Cursor Agent transcript {} from index", filename),
+                    );
+                    return Some(ConversationLoad::Cached(conversation));
+                }
 
                 match process_transcript_file(
                     path.clone(),
@@ -152,7 +184,7 @@ impl CursorAgentProvider {
                     workspace_path.clone(),
                     debug_level,
                 ) {
-                    Ok(Some(conversation)) => {
+                    Ok(Some(mut conversation)) => {
                         debug::debug(
                             debug_level,
                             &format!(
@@ -160,7 +192,13 @@ impl CursorAgentProvider {
                                 filename, conversation.preview
                             ),
                         );
-                        Some(conversation)
+                        attach_search_cache(&mut conversation);
+                        match fingerprint {
+                            Some(fingerprint) => {
+                                Some(ConversationLoad::Fresh(conversation, fingerprint))
+                            }
+                            None => Some(ConversationLoad::Cached(conversation)),
+                        }
                     }
                     Ok(None) => None,
                     Err(err) => {
@@ -175,6 +213,22 @@ impl CursorAgentProvider {
                     }
                 }
             })
+            .collect();
+
+        save_conversations(
+            ProviderKind::CursorAgent,
+            show_last,
+            loaded.iter().filter_map(|loaded| match loaded {
+                ConversationLoad::Fresh(conversation, fingerprint) => {
+                    Some((conversation, *fingerprint))
+                }
+                ConversationLoad::Cached(_) => None,
+            }),
+        );
+
+        let mut conversations: Vec<Conversation> = loaded
+            .into_iter()
+            .map(ConversationLoad::into_conversation)
             .collect();
 
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
@@ -208,9 +262,12 @@ impl super::Provider for CursorAgentProvider {
             return Ok(Vec::new());
         }
 
+        let cache = load_provider_cache(ProviderKind::CursorAgent, show_last);
         let mut conversations: Vec<Conversation> = projects
             .iter()
-            .flat_map(|project| self.load_project_conversations(project, show_last, debug_level))
+            .flat_map(|project| {
+                self.load_project_conversations(project, show_last, debug_level, &cache)
+            })
             .collect();
 
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
@@ -239,9 +296,10 @@ impl super::Provider for CursorAgentProvider {
                 }
             };
 
+            let cache = load_provider_cache(ProviderKind::CursorAgent, show_last);
             for project in &projects {
                 let conversations =
-                    provider.load_project_conversations(project, show_last, debug_level);
+                    provider.load_project_conversations(project, show_last, debug_level, &cache);
                 if !conversations.is_empty() {
                     let _ = tx.send(LoaderMessage::Batch(conversations));
                 }
@@ -453,6 +511,8 @@ fn process_transcript_file(
         model: None,
         total_tokens: 0,
         duration_minutes,
+        search_text_lower: None,
+        search_topic_end: None,
     }))
 }
 
@@ -625,6 +685,12 @@ fn load_workspace_path(project_dir: &Path) -> Option<PathBuf> {
 
 fn file_modified_time(path: &Path) -> Option<SystemTime> {
     fs::metadata(path).ok()?.modified().ok()
+}
+
+fn file_fingerprint(path: &Path) -> Option<SourceFingerprint> {
+    fs::metadata(path)
+        .ok()
+        .map(|metadata| fingerprint_from_metadata(&metadata))
 }
 
 fn transcript_parent_dir(path: &Path, conversation_id: &str) -> Option<PathBuf> {
@@ -820,6 +886,8 @@ mod tests {
             model: None,
             total_tokens: 0,
             duration_minutes: None,
+            search_text_lower: None,
+            search_topic_end: None,
         };
 
         provider.delete(&conversation).unwrap();

--- a/src/providers/cursor_agent.rs
+++ b/src/providers/cursor_agent.rs
@@ -3,8 +3,8 @@ use crate::claude::{
 };
 use crate::cli::DebugLevel;
 use crate::conversation_index::{
-    CachedFileConversation, SourceFingerprint, attach_search_cache, fingerprint_from_metadata,
-    load_provider_cache, save_conversations,
+    CachedFileConversation, SourceFingerprint, attach_search_cache, delete_conversation,
+    fingerprint_from_metadata, load_provider_cache, save_conversations,
 };
 use crate::debug;
 use crate::error::{AppError, Result};
@@ -367,11 +367,13 @@ impl super::Provider for CursorAgentProvider {
         if let Some(transcript_dir) = transcript_parent_dir(&conversation.path, &conversation.id) {
             if transcript_dir.exists() {
                 fs::remove_dir_all(transcript_dir)?;
+                delete_conversation(ProviderKind::CursorAgent, &conversation.path);
                 return Ok(());
             }
         }
 
         fs::remove_file(&conversation.path)?;
+        delete_conversation(ProviderKind::CursorAgent, &conversation.path);
         Ok(())
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -301,17 +301,13 @@ impl App {
     }
 
     /// Append a batch of conversations during loading.
-    /// Maintains sorted order (newest first) so the list looks correct while loading.
-    /// Note: Does NOT precompute search text - that's deferred to finish_loading.
+    /// Defers global sort and search precompute until finish_loading to avoid
+    /// repeated O(n log n) work while provider batches are still arriving.
     pub fn append_conversations(&mut self, mut new_convs: Vec<Conversation>) {
         if !self.show_deleted_projects {
             new_convs.retain(|c| c.project_path.as_ref().map_or(true, |p| p.exists()));
         }
         self.conversations.extend(new_convs);
-
-        // Re-sort all conversations by timestamp (newest first)
-        self.conversations
-            .sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
 
         // Rebuild filtered as sequential indices (no search during loading)
         self.filtered = (0..self.conversations.len()).collect();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,6 +1,6 @@
 mod app;
 mod export;
-mod search;
+pub(crate) mod search;
 mod ui;
 pub mod viewer;
 

--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -49,6 +49,19 @@ struct QueryTerm<'a> {
     completed: bool,
 }
 
+/// Find a char-boundary at or after TOPIC_WINDOW_SIZE bytes.
+pub fn topic_end_for_text(text: &str) -> usize {
+    if text.len() <= TOPIC_WINDOW_SIZE {
+        text.len()
+    } else {
+        let mut end = TOPIC_WINDOW_SIZE;
+        while !text.is_char_boundary(end) && end < text.len() {
+            end += 1;
+        }
+        end
+    }
+}
+
 /// Precompute lowercased search text for all conversations.
 /// Moves `full_text` ownership from each Conversation into SearchableConversation
 /// to avoid storing the same text twice in memory.
@@ -58,18 +71,14 @@ pub fn precompute_search_text(conversations: &mut [Conversation]) -> Vec<Searcha
         .enumerate()
         .map(|(idx, conv)| {
             let full_text = std::mem::take(&mut conv.full_text);
-            let text_lower = normalize_for_search(&full_text);
-            // Find a char-boundary at or after TOPIC_WINDOW_SIZE bytes
-            let topic_end = if text_lower.len() <= TOPIC_WINDOW_SIZE {
-                text_lower.len()
-            } else {
-                // Advance past TOPIC_WINDOW_SIZE to the next char boundary
-                let mut end = TOPIC_WINDOW_SIZE;
-                while !text_lower.is_char_boundary(end) && end < text_lower.len() {
-                    end += 1;
-                }
-                end
-            };
+            let text_lower = conv
+                .search_text_lower
+                .take()
+                .unwrap_or_else(|| normalize_for_search(&full_text));
+            let topic_end = conv
+                .search_topic_end
+                .take()
+                .unwrap_or_else(|| topic_end_for_text(&text_lower));
             SearchableConversation {
                 text_lower,
                 full_text,
@@ -291,6 +300,8 @@ mod tests {
             model: None,
             total_tokens: 0,
             duration_minutes: None,
+            search_text_lower: None,
+            search_topic_end: None,
         }
     }
 
@@ -430,10 +441,7 @@ mod tests {
                 now,
             ),
             // Dense: "deploy" appears many times in a short text
-            make_conv(
-                "deploy deploy deploy the deploy fix for deploy",
-                now,
-            ),
+            make_conv("deploy deploy deploy the deploy fix for deploy", now),
         ];
         let searchable = precompute_search_text(&mut convs);
         let results = search(&convs, &searchable, "deploy", now, None);
@@ -453,16 +461,16 @@ mod tests {
                 now - Duration::days(60),
             ),
             // Recent but barely relevant: "webpack" mentioned once, buried past the topic window
-            make_conv(
-                &format!("{padding} someone mentioned webpack once"),
-                now,
-            ),
+            make_conv(&format!("{padding} someone mentioned webpack once"), now),
         ];
         let searchable = precompute_search_text(&mut convs);
         let results = search(&convs, &searchable, "webpack", now, None);
         assert_eq!(results.len(), 2);
         // The highly relevant old conversation should beat the barely-relevant recent one
-        assert_eq!(results[0], 0, "highly relevant old convo should rank above barely relevant recent one");
+        assert_eq!(
+            results[0], 0,
+            "highly relevant old convo should rank above barely relevant recent one"
+        );
     }
 
     #[test]
@@ -473,21 +481,18 @@ mod tests {
         let padding = "x ".repeat(1500); // ~3000 chars of padding
         let mut convs = vec![
             // "migrate" only in the body (after the topic window)
-            make_conv(
-                &format!("{padding}migrate migrate migrate"),
-                now,
-            ),
+            make_conv(&format!("{padding}migrate migrate migrate"), now),
             // "migrate" in the topic window (beginning of conversation)
-            make_conv(
-                &format!("migrate migrate migrate {padding}"),
-                now,
-            ),
+            make_conv(&format!("migrate migrate migrate {padding}"), now),
         ];
         let searchable = precompute_search_text(&mut convs);
         let results = search(&convs, &searchable, "migrate", now, None);
         assert_eq!(results.len(), 2);
         // The conversation with topic-window hits should rank first
-        assert_eq!(results[0], 1, "topic-window match should rank higher than body-only match");
+        assert_eq!(
+            results[0], 1,
+            "topic-window match should rank higher than body-only match"
+        );
     }
 
     #[test]
@@ -505,7 +510,10 @@ mod tests {
         // "dia" as whole word should not match "diagnostics"
         assert_eq!(count_occurrences("diagnostics are useful", "dia", true), 0);
         // "dia" as whole word should match "dia" followed by space
-        assert_eq!(count_occurrences("dia is short for diagram", "dia", true), 1);
+        assert_eq!(
+            count_occurrences("dia is short for diagram", "dia", true),
+            1
+        );
         // "dia" at end of string
         assert_eq!(count_occurrences("this is dia", "dia", true), 1);
         // "dia" followed by punctuation
@@ -531,8 +539,15 @@ mod tests {
 
         // With trailing space: only the standalone "dia" matches
         let results = search(&convs, &searchable, "dia ", now, None);
-        assert_eq!(results.len(), 1, "completed term should only match whole word");
-        assert_eq!(results[0], 1, "should match the conversation with standalone 'dia'");
+        assert_eq!(
+            results.len(),
+            1,
+            "completed term should only match whole word"
+        );
+        assert_eq!(
+            results[0], 1,
+            "should match the conversation with standalone 'dia'"
+        );
     }
 
     #[test]
@@ -541,12 +556,18 @@ mod tests {
         let terms = parse_query_terms("foo bar");
         assert_eq!(terms.len(), 2);
         assert!(!terms[0].completed, "interior term is never completed");
-        assert!(!terms[1].completed, "last term without trailing space should not be completed");
+        assert!(
+            !terms[1].completed,
+            "last term without trailing space should not be completed"
+        );
 
         let terms = parse_query_terms("foo bar ");
         assert_eq!(terms.len(), 2);
         assert!(!terms[0].completed, "interior term is never completed");
-        assert!(terms[1].completed, "last term with trailing space should be completed");
+        assert!(
+            terms[1].completed,
+            "last term with trailing space should be completed"
+        );
 
         let terms = parse_query_terms("single");
         assert_eq!(terms.len(), 1);


### PR DESCRIPTION
## Summary
- Add a persistent SQLite sidecar index for file-backed conversations so warm starts can reuse parsed metadata and normalized search text.
- Wire the index into Claude Code and Cursor Agent loading with mtime/size invalidation for changed transcripts.
- Defer full-list sorting during streaming load and make the markdown code-block test independent of ANSI color state.

## Test plan
- [x] cargo test
- [x] git diff --check