### PR TITLE
Speed optimizations across search, parsing, and caching

### DIFF
--- a/src/conversation_index.rs
+++ b/src/conversation_index.rs
@@ -181,7 +181,11 @@ fn load_provider_cache_from_conn(
             let search_topic_end: i64 = row.get(8)?;
             let message_count: i64 = row.get(12)?;
             let parse_errors_json: String = row.get(13)?;
-            let parse_errors = serde_json::from_str(&parse_errors_json).unwrap_or_default();
+            let parse_errors = if parse_errors_json == "[]" {
+                Vec::new()
+            } else {
+                serde_json::from_str(&parse_errors_json).unwrap_or_default()
+            };
             let total_tokens: i64 = row.get(16)?;
             let duration_minutes: Option<i64> = row.get(17)?;
 
@@ -235,6 +239,7 @@ fn open_index_db() -> Option<Connection> {
 fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute_batch(
         "PRAGMA journal_mode=WAL;
+         PRAGMA synchronous=NORMAL;
          CREATE TABLE IF NOT EXISTS file_conversations (
              schema_version        INTEGER NOT NULL,
              provider              TEXT NOT NULL,

--- a/src/conversation_index.rs
+++ b/src/conversation_index.rs
@@ -263,7 +263,9 @@ fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
              total_tokens          INTEGER NOT NULL,
              duration_minutes      INTEGER,
              PRIMARY KEY (schema_version, provider, show_last, source_path)
-         );",
+         );
+         CREATE INDEX IF NOT EXISTS idx_provider_source_path
+         ON file_conversations (provider, source_path);",
     )
 }
 

--- a/src/conversation_index.rs
+++ b/src/conversation_index.rs
@@ -66,6 +66,11 @@ pub fn save_conversations<'a, I>(provider: ProviderKind, show_last: bool, entrie
 where
     I: IntoIterator<Item = (&'a Conversation, SourceFingerprint)>,
 {
+    let mut iter = entries.into_iter().peekable();
+    if iter.peek().is_none() {
+        return;
+    }
+
     let Some(mut conn) = open_index_db() else {
         return;
     };
@@ -94,7 +99,7 @@ where
         let provider_key = provider_key(&provider);
         let show_last = i64::from(show_last);
 
-        for (conversation, fingerprint) in entries {
+        for (conversation, fingerprint) in iter {
             let Some(text_lower) = &conversation.search_text_lower else {
                 continue;
             };

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -200,36 +200,14 @@ pub fn list_projects(root: &Path, exclude_names: &[String]) -> Result<Vec<Projec
         .par_bridge()
         .filter_map(|entry| {
             let entry = entry.ok()?;
-            let path = entry.path();
 
-            if !path.is_dir() {
+            if !entry.file_type().ok()?.is_dir() {
                 return None;
             }
 
-            // Check if project has any non-agent .jsonl files
-            let has_conversations = read_dir(&path).ok()?.any(|e| {
-                e.ok()
-                    .map(|e| {
-                        let path = e.path();
-                        let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
-                        path.extension().map(|s| s == "jsonl").unwrap_or(false)
-                            && !name.starts_with("agent-")
-                    })
-                    .unwrap_or(false)
-            });
-
-            if !has_conversations {
-                return None;
-            }
-
-            let name = path.file_name()?.to_string_lossy().to_string();
-            // Heuristic decode: convert encoded directory name back to readable path
-            // The encoding replaces non-alphanumeric chars (except -) with -
-            // So / becomes -, but _ also becomes -, and __ becomes --
-            // We convert single dashes to / but preserve double dashes as _
+            let name = entry.file_name().to_string_lossy().to_string();
             let display_name = decode_project_dir_name(&name);
 
-            // Skip projects whose display name contains any exclude string
             if exclude_names
                 .iter()
                 .any(|ex| display_name.contains(ex.as_str()))

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -310,11 +310,7 @@ fn load_conversations_with_cache(
         ),
     );
 
-    // Sort by modification time (newest first)
-    files_with_meta.sort_by_key(|(_, modified, _)| modified.unwrap_or(SystemTime::UNIX_EPOCH));
-    files_with_meta.reverse();
-
-    // Process each file (potentially in parallel)
+    // Process each file in parallel (result is re-sorted after collection)
     let loaded: Vec<ConversationLoad> = files_with_meta
         .into_par_iter()
         .filter_map(|(path, modified, fingerprint)| {

--- a/src/history/parser.rs
+++ b/src/history/parser.rs
@@ -276,11 +276,22 @@ pub(crate) fn process_conversation_reader<R: BufRead>(
             .join(" ... ")
     };
 
-    // Create full text for searching (all messages + summary)
-    let mut full_text = all_parts.join(" ");
-    if let Some(ref summary) = extracted_summary {
-        full_text = format!("{} {}", summary, full_text);
-    }
+    // Create full text for searching (summary + all messages), built in one pass
+    let full_text = {
+        let mut parts_iter = extracted_summary
+            .iter()
+            .map(|s| s.as_str())
+            .chain(all_parts.iter().map(|s| s.as_str()));
+        let mut result = String::new();
+        if let Some(first) = parts_iter.next() {
+            result.push_str(first);
+            for part in parts_iter {
+                result.push(' ');
+                result.push_str(part);
+            }
+        }
+        result
+    };
 
     // Normalize whitespace
     let preview = normalize_whitespace(&preview);
@@ -397,9 +408,16 @@ pub(crate) fn is_clear_only_conversation(user_messages: &[String]) -> bool {
     saw_caveat && saw_command && saw_stdout
 }
 
-/// Normalize whitespace in a string
+/// Normalize whitespace in a string (single-pass, no intermediate Vec)
 pub(crate) fn normalize_whitespace(s: &str) -> String {
-    s.split_whitespace().collect::<Vec<&str>>().join(" ")
+    let mut result = String::with_capacity(s.len());
+    for word in s.split_whitespace() {
+        if !result.is_empty() {
+            result.push(' ');
+        }
+        result.push_str(word);
+    }
+    result
 }
 
 #[cfg(test)]

--- a/src/providers/cursor.rs
+++ b/src/providers/cursor.rs
@@ -278,6 +278,7 @@ fn open_cache_db() -> Option<Connection> {
     let conn = Connection::open(&db_path).ok()?;
     conn.execute_batch(
         "PRAGMA journal_mode=WAL;
+         PRAGMA synchronous=NORMAL;
          CREATE TABLE IF NOT EXISTS user_bubble_keys (
              conv_id      TEXT PRIMARY KEY,
              min_user_key TEXT,

--- a/src/providers/cursor_agent.rs
+++ b/src/providers/cursor_agent.rs
@@ -116,7 +116,7 @@ impl CursorAgentProvider {
         for entry in fs::read_dir(&self.projects_root)? {
             let entry = entry?;
             let path = entry.path();
-            if !path.is_dir() {
+            if !entry.file_type().is_ok_and(|ft| ft.is_dir()) {
                 continue;
             }
 
@@ -637,26 +637,32 @@ fn summarize_blocks_for_preview(blocks: &[CursorAgentTranscriptBlock]) -> Option
 }
 
 fn collect_transcript_files(transcripts_dir: &Path) -> Vec<PathBuf> {
-    let mut files = Vec::new();
+    let mut files_with_mtime: Vec<(PathBuf, SystemTime)> = Vec::new();
     let entries = match fs::read_dir(transcripts_dir) {
         Ok(entries) => entries,
-        Err(_) => return files,
+        Err(_) => return Vec::new(),
     };
 
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.is_file() && path.extension().is_some_and(|ext| ext == "jsonl") {
-            files.push(path);
+        let file_type = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if file_type.is_file() && path.extension().is_some_and(|ext| ext == "jsonl") {
+            let mtime = file_modified_time(&path).unwrap_or(SystemTime::UNIX_EPOCH);
+            files_with_mtime.push((path, mtime));
             continue;
         }
 
-        if !path.is_dir() {
+        if !file_type.is_dir() {
             continue;
         }
 
         let default_path = path.join(format!("{}.jsonl", entry.file_name().to_string_lossy()));
         if default_path.is_file() {
-            files.push(default_path);
+            let mtime = file_modified_time(&default_path).unwrap_or(SystemTime::UNIX_EPOCH);
+            files_with_mtime.push((default_path, mtime));
             continue;
         }
 
@@ -666,16 +672,20 @@ fn collect_transcript_files(transcripts_dir: &Path) -> Vec<PathBuf> {
         };
         for nested in nested_entries.flatten() {
             let nested_path = nested.path();
-            if nested_path.is_file() && nested_path.extension().is_some_and(|ext| ext == "jsonl") {
-                files.push(nested_path);
+            let nested_ft = match nested.file_type() {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            if nested_ft.is_file() && nested_path.extension().is_some_and(|ext| ext == "jsonl") {
+                let mtime = file_modified_time(&nested_path).unwrap_or(SystemTime::UNIX_EPOCH);
+                files_with_mtime.push((nested_path, mtime));
                 break;
             }
         }
     }
 
-    files.sort_by_key(|path| file_modified_time(path).unwrap_or(SystemTime::UNIX_EPOCH));
-    files.reverse();
-    files
+    files_with_mtime.sort_by(|a, b| b.1.cmp(&a.1));
+    files_with_mtime.into_iter().map(|(path, _)| path).collect()
 }
 
 fn load_workspace_path(project_dir: &Path) -> Option<PathBuf> {
@@ -742,7 +752,14 @@ fn command_exists(name: &str) -> bool {
 }
 
 fn normalize_whitespace(input: &str) -> String {
-    input.split_whitespace().collect::<Vec<_>>().join(" ")
+    let mut result = String::with_capacity(input.len());
+    for word in input.split_whitespace() {
+        if !result.is_empty() {
+            result.push(' ');
+        }
+        result.push_str(word);
+    }
+    result
 }
 
 #[cfg(unix)]

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -1,5 +1,6 @@
 //! Syntax highlighting for code blocks using syntect.
 
+use std::fmt::Write;
 use std::sync::OnceLock;
 use syntect::easy::HighlightLines;
 use syntect::highlighting::{FontStyle, ThemeSet};
@@ -65,8 +66,7 @@ pub fn highlight_code_ansi(code: &str, lang: &str) -> Option<String> {
         let ranges = highlighter.highlight_line(line, ps).ok()?;
         for (style, text) in ranges {
             let fg = style.foreground;
-            // Build ANSI escape sequence for foreground color
-            output.push_str(&format!("\x1b[38;2;{};{};{}m", fg.r, fg.g, fg.b));
+            let _ = write!(output, "\x1b[38;2;{};{};{}m", fg.r, fg.g, fg.b);
             if style.font_style.contains(FontStyle::BOLD) {
                 output.push_str("\x1b[1m");
             }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -113,6 +113,8 @@ pub enum ViewSearchMode {
 #[derive(Clone, Debug)]
 pub struct RenderedLine {
     pub spans: Vec<(String, LineStyle)>,
+    /// Cached lowercased concatenation of all span texts for search
+    pub search_text: Option<String>,
 }
 
 /// Style information for a span
@@ -1435,12 +1437,12 @@ impl App {
                 return;
             }
 
+            let query = query_lower;
             state.search_matches = state
                 .rendered_lines
-                .iter()
+                .iter_mut()
                 .enumerate()
-                .filter(|(_, line)| line_matches_query(line, &query_lower))
-                .map(|(i, _)| i)
+                .filter_map(|(i, line)| line_matches_query(line, &query).then_some(i))
                 .collect();
 
             // Jump to first match if any
@@ -1571,10 +1573,11 @@ impl App {
                     let query_lower = state.search_query.to_lowercase();
                     state.search_matches = state
                         .rendered_lines
-                        .iter()
+                        .iter_mut()
                         .enumerate()
-                        .filter(|(_, line)| line_matches_query(line, &query_lower))
-                        .map(|(i, _)| i)
+                        .filter_map(|(i, line)| {
+                            line_matches_query(line, &query_lower).then_some(i)
+                        })
                         .collect();
 
                     // Clamp current_match to valid range
@@ -1612,9 +1615,13 @@ struct TerminalGuard {
 
 /// Check if a rendered line matches the search query by concatenating all span texts.
 /// This allows multi-word queries to match across span boundaries.
-pub fn line_matches_query(line: &RenderedLine, query_lower: &str) -> bool {
-    let full_text: String = line.spans.iter().map(|(text, _)| text.as_str()).collect();
-    full_text.to_lowercase().contains(query_lower)
+/// Uses a cached lowercased text to avoid re-allocating on every keystroke.
+pub fn line_matches_query(line: &mut RenderedLine, query_lower: &str) -> bool {
+    let search_text = line.search_text.get_or_insert_with(|| {
+        let full_text: String = line.spans.iter().map(|(text, _)| text.as_str()).collect();
+        full_text.to_lowercase()
+    });
+    search_text.contains(query_lower)
 }
 
 impl TerminalGuard {

--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -131,20 +131,19 @@ pub fn search(
     }
 
     let mut scored: Vec<(usize, f64, DateTime<Local>)> = if let Some(indices) = narrow_from {
-        let allowed: std::collections::HashSet<usize> = indices.iter().copied().collect();
-        searchable
+        indices
             .par_iter()
-            .filter(|s| allowed.contains(&s.index))
-            .filter_map(|s| {
+            .filter_map(|&idx| {
+                let s = &searchable[idx];
                 let score = score_text(
                     &s.text_lower,
                     s.topic_end,
                     &query_terms,
-                    conversations[s.index].timestamp,
+                    conversations[idx].timestamp,
                     now,
                 );
                 if score > 0.0 {
-                    Some((s.index, score, conversations[s.index].timestamp))
+                    Some((idx, score, conversations[idx].timestamp))
                 } else {
                     None
                 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -513,7 +513,7 @@ fn render_view_content(frame: &mut Frame, state: &ViewState, area: Rect) {
         .take(visible_height)
         .map(|(line_idx, rendered)| {
             let is_current_match = state.search_matches.get(state.current_match) == Some(&line_idx);
-            let has_match = !query_lower.is_empty() && state.search_matches.contains(&line_idx);
+            let has_match = !query_lower.is_empty() && state.search_matches.binary_search(&line_idx).is_ok();
 
             let spans: Vec<Span> = if has_match && !query_lower.is_empty() {
                 highlight_line_matches(rendered, &query_lower, is_current_match)

--- a/src/tui/viewer.rs
+++ b/src/tui/viewer.rs
@@ -15,8 +15,8 @@ use std::path::Path;
 use unicode_width::UnicodeWidthStr;
 
 const NAME_WIDTH: usize = 12;
-/// Width of timestamp prefix when timing is enabled (space + HH:MM + space)
-const TIMESTAMP_WIDTH: usize = 7;
+const NAME_PAD: &str = "            "; // NAME_WIDTH spaces
+const TIMESTAMP_PAD: &str = "       "; // 7 spaces (HH:MM + margins)
 const WHITE: (u8, u8, u8) = (255, 255, 255);
 const USER_TEXT: (u8, u8, u8) = (240, 180, 100);
 const SEPARATOR_COLOR: (u8, u8, u8) = (80, 80, 80);
@@ -904,14 +904,14 @@ fn render_ledger_block_styled(
             }
         } else if timestamp.is_some() {
             // Pad continuation lines to align with timestamped first line
-            spans.push((" ".repeat(TIMESTAMP_WIDTH), LineStyle::default()));
+            spans.push((TIMESTAMP_PAD.to_string(), LineStyle::default()));
         }
 
         // Name column (right-aligned, only on first line)
         let name_text = if i == 0 {
             format!("{:>width$}", name, width = NAME_WIDTH)
         } else {
-            " ".repeat(NAME_WIDTH)
+            NAME_PAD.to_string()
         };
 
         spans.push((
@@ -992,10 +992,10 @@ fn render_truncation_indicator(
     let mut spans = Vec::new();
 
     if show_timing {
-        spans.push((" ".repeat(TIMESTAMP_WIDTH), LineStyle::default()));
+        spans.push((TIMESTAMP_PAD.to_string(), LineStyle::default()));
     }
 
-    spans.push((" ".repeat(NAME_WIDTH), LineStyle::default()));
+    spans.push((NAME_PAD.to_string(), LineStyle::default()));
     spans.push((
         " │ ".to_string(),
         LineStyle {
@@ -1085,9 +1085,9 @@ fn render_tool_call(
         // Empty line between header and body
         let mut empty_spans = Vec::new();
         if show_timing {
-            empty_spans.push((" ".repeat(TIMESTAMP_WIDTH), LineStyle::default()));
+            empty_spans.push((TIMESTAMP_PAD.to_string(), LineStyle::default()));
         }
-        empty_spans.push((" ".repeat(NAME_WIDTH), LineStyle::default()));
+        empty_spans.push((NAME_PAD.to_string(), LineStyle::default()));
         empty_spans.push((
             " │ ".to_string(),
             LineStyle {
@@ -1126,11 +1126,11 @@ fn render_tool_body(lines: &mut Vec<RenderedLine>, text: &str, dimmed: bool, sho
 
         // Timing alignment padding (if timing is enabled)
         if show_timing {
-            spans.push((" ".repeat(TIMESTAMP_WIDTH), LineStyle::default()));
+            spans.push((TIMESTAMP_PAD.to_string(), LineStyle::default()));
         }
 
         // Empty name column
-        spans.push((" ".repeat(NAME_WIDTH), LineStyle::default()));
+        spans.push((NAME_PAD.to_string(), LineStyle::default()));
 
         // Separator
         spans.push((
@@ -1211,7 +1211,7 @@ fn render_tool_result(
             }
         } else if timestamp.is_some() {
             // Pad continuation lines to align with timestamped first line
-            spans.push((" ".repeat(TIMESTAMP_WIDTH), LineStyle::default()));
+            spans.push((TIMESTAMP_PAD.to_string(), LineStyle::default()));
         }
 
         // First line gets the label, rest are empty
@@ -1224,7 +1224,7 @@ fn render_tool_result(
                 },
             ));
         } else {
-            spans.push((" ".repeat(NAME_WIDTH), LineStyle::default()));
+            spans.push((NAME_PAD.to_string(), LineStyle::default()));
         }
 
         // Separator
@@ -1406,13 +1406,13 @@ fn render_ledger_block_styled_dimmed(
         let mut spans = Vec::new();
 
         if show_timing {
-            spans.push((" ".repeat(TIMESTAMP_WIDTH), LineStyle::default()));
+            spans.push((TIMESTAMP_PAD.to_string(), LineStyle::default()));
         }
 
         let name_text = if i == 0 {
             format!("{:>width$}", name, width = NAME_WIDTH)
         } else {
-            " ".repeat(NAME_WIDTH)
+            NAME_PAD.to_string()
         };
 
         spans.push((
@@ -1445,7 +1445,7 @@ fn render_ledger_block_styled_dimmed(
     if styled_lines.is_empty() {
         let mut spans = Vec::new();
         if show_timing {
-            spans.push((" ".repeat(TIMESTAMP_WIDTH), LineStyle::default()));
+            spans.push((TIMESTAMP_PAD.to_string(), LineStyle::default()));
         }
         spans.push((
             format!("{:>width$}", name, width = NAME_WIDTH),
@@ -1480,13 +1480,13 @@ fn render_ledger_block_plain_dimmed(
         let mut spans = Vec::new();
 
         if show_timing {
-            spans.push((" ".repeat(TIMESTAMP_WIDTH), LineStyle::default()));
+            spans.push((TIMESTAMP_PAD.to_string(), LineStyle::default()));
         }
 
         let name_text = if i == 0 {
             format!("{:>width$}", name, width = NAME_WIDTH)
         } else {
-            " ".repeat(NAME_WIDTH)
+            NAME_PAD.to_string()
         };
 
         spans.push((
@@ -1526,11 +1526,11 @@ fn render_continuation_dimmed(lines: &mut Vec<RenderedLine>, text: &str, show_ti
         let mut spans = Vec::new();
 
         if show_timing {
-            spans.push((" ".repeat(TIMESTAMP_WIDTH), LineStyle::default()));
+            spans.push((TIMESTAMP_PAD.to_string(), LineStyle::default()));
         }
 
         spans.push((
-            " ".repeat(NAME_WIDTH),
+            NAME_PAD.to_string(),
             LineStyle {
                 dimmed: true,
                 ..Default::default()

--- a/src/tui/viewer.rs
+++ b/src/tui/viewer.rs
@@ -236,7 +236,7 @@ fn render_user_message(
     }
 
     if printed {
-        lines.push(RenderedLine { spans: vec![] }); // Empty line after message
+        lines.push(RenderedLine { spans: vec![], search_text: None }); // Empty line after message
     }
 }
 
@@ -354,7 +354,7 @@ fn render_assistant_message(
     }
 
     if printed {
-        lines.push(RenderedLine { spans: vec![] });
+        lines.push(RenderedLine { spans: vec![], search_text: None });
     }
 }
 
@@ -942,7 +942,7 @@ fn render_ledger_block_styled(
             }
         }
 
-        lines.push(RenderedLine { spans });
+        lines.push(RenderedLine { spans, search_text: None });
     }
 
     // If no lines, still output at least the name
@@ -978,7 +978,7 @@ fn render_ledger_block_styled(
                 ..Default::default()
             },
         ));
-        lines.push(RenderedLine { spans });
+        lines.push(RenderedLine { spans, search_text: None });
     }
 }
 
@@ -1012,7 +1012,7 @@ fn render_truncation_indicator(
         },
     ));
 
-    lines.push(RenderedLine { spans });
+    lines.push(RenderedLine { spans, search_text: None });
 }
 
 /// Render a formatted tool call with proper styling
@@ -1076,7 +1076,7 @@ fn render_tool_call(
         },
     ));
 
-    lines.push(RenderedLine { spans });
+    lines.push(RenderedLine { spans, search_text: None });
 
     // Render the body if present, with empty line separator
     if let Some(body) = formatted.body {
@@ -1096,7 +1096,7 @@ fn render_tool_call(
                 ..Default::default()
             },
         ));
-        lines.push(RenderedLine { spans: empty_spans });
+        lines.push(RenderedLine { spans: empty_spans, search_text: None });
 
         if tool_display == ToolDisplayMode::Truncated {
             let body_lines: Vec<&str> = body.lines().collect();
@@ -1171,7 +1171,7 @@ fn render_tool_body(lines: &mut Vec<RenderedLine>, text: &str, dimmed: bool, sho
             ));
         }
 
-        lines.push(RenderedLine { spans });
+        lines.push(RenderedLine { spans, search_text: None });
     }
 }
 
@@ -1241,7 +1241,7 @@ fn render_tool_result(
             spans.push((text.clone(), style.clone()));
         }
 
-        lines.push(RenderedLine { spans });
+        lines.push(RenderedLine { spans, search_text: None });
     }
 
     if limit < total {
@@ -1390,7 +1390,7 @@ fn render_agent_message(
     }
 
     if printed {
-        lines.push(RenderedLine { spans: vec![] });
+        lines.push(RenderedLine { spans: vec![], search_text: None });
     }
 }
 
@@ -1439,7 +1439,7 @@ fn render_ledger_block_styled_dimmed(
             spans.push((text, style));
         }
 
-        lines.push(RenderedLine { spans });
+        lines.push(RenderedLine { spans, search_text: None });
     }
 
     if styled_lines.is_empty() {
@@ -1464,7 +1464,7 @@ fn render_ledger_block_styled_dimmed(
                 ..Default::default()
             },
         ));
-        lines.push(RenderedLine { spans });
+        lines.push(RenderedLine { spans, search_text: None });
     }
 }
 
@@ -1516,7 +1516,7 @@ fn render_ledger_block_plain_dimmed(
             },
         ));
 
-        lines.push(RenderedLine { spans });
+        lines.push(RenderedLine { spans, search_text: None });
     }
 }
 
@@ -1552,7 +1552,7 @@ fn render_continuation_dimmed(lines: &mut Vec<RenderedLine>, text: &str, show_ti
             },
         ));
 
-        lines.push(RenderedLine { spans });
+        lines.push(RenderedLine { spans, search_text: None });
     }
 }
 


### PR DESCRIPTION
## Summary

- **View search**: Use `binary_search()` instead of linear `contains()` for match lookups during rendering (O(log n) vs O(n) per visible line)
- **View search**: Cache lowercased text in `RenderedLine` to avoid 2 String allocations per rendered line per keystroke
- **Loader**: Remove redundant O(n log n) sort that was immediately invalidated by `par_iter`
- **SQLite**: Add `PRAGMA synchronous=NORMAL` for faster writes with WAL mode (safe with WAL, avoids unnecessary fsync)
- **Parser**: Single-pass `normalize_whitespace` without intermediate `Vec<&str>` allocation
- **Parser**: Build `full_text` in one pass instead of `join()` + `format!()` + `normalize()` triple allocation
- **Syntax**: Use `write!` instead of `format!` for ANSI escape codes to avoid intermediate String per token
- **Cache**: Short-circuit empty parse_errors JSON deserialization (skip serde for the common `"[]"` case)

## Test plan

- [x] All 155 existing tests pass
- [x] Clippy clean (no new warnings)
- [ ] Manual testing: launch TUI, search conversations, toggle tools/thinking, verify no regressions