### PR TITLE
Add Codex provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Universal AI coding conversation history browser. Search, browse, and resume con
 | Tool | History Format | Resume Support |
 |------|---------------|----------------|
 | **Claude Code** | JSONL files in `~/.claude/projects/` | `claude --resume <session-id>` |
+| **Codex** | JSONL transcripts in `$CODEX_HOME/sessions/` (default `~/.codex/sessions/`) | `codex resume <session-id>` |
 | **Cursor Agent CLI** | JSONL transcripts in `~/.cursor/projects/*/agent-transcripts/` | `agent --resume <chat-id>` |
 | **Cursor (IDE)** | SQLite in workspace storage | Bridge extension + `cursor://` URI |
 

--- a/src/conversation_index.rs
+++ b/src/conversation_index.rs
@@ -265,6 +265,7 @@ fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
 fn provider_key(provider: &ProviderKind) -> &'static str {
     match provider {
         ProviderKind::Claude => "claude",
+        ProviderKind::Codex => "codex",
         ProviderKind::Cursor => "cursor",
         ProviderKind::CursorAgent => "cursor-agent",
     }

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -30,6 +30,7 @@ pub use path::{convert_path_to_project_dir_name, format_short_name_from_path};
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ProviderKind {
     Claude,
+    Codex,
     Cursor,
     CursorAgent,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,7 @@ fn run() -> Result<()> {
     let exclude_paths = config.exclude.unwrap_or_default();
     let providers: Vec<Box<dyn Provider>> = vec![
         Box::new(providers::claude::ClaudeProvider::new(exclude_paths)),
+        Box::new(providers::codex::CodexProvider::new()),
         Box::new(providers::cursor_agent::CursorAgentProvider::new()),
         Box::new(providers::cursor::CursorProvider::new()),
     ];

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -1,0 +1,943 @@
+use crate::claude::{AssistantMessage, ContentBlock, LogEntry, UserContent, UserMessage};
+use crate::cli::DebugLevel;
+use crate::conversation_index::{
+    SourceFingerprint, attach_search_cache, delete_conversation, fingerprint_from_metadata,
+    load_provider_cache, save_conversations,
+};
+use crate::debug;
+use crate::error::{AppError, Result};
+use crate::history::{
+    Conversation, LoaderMessage, ParseError, ProviderKind, format_short_name_from_path,
+};
+use chrono::{DateTime, FixedOffset, Local};
+use rayon::prelude::*;
+use serde_json::Value;
+use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::mpsc::{self, Receiver};
+use std::time::SystemTime;
+
+pub struct CodexProvider {
+    codex_home: PathBuf,
+}
+
+struct ParsedCodexTranscript {
+    conversation: Option<Conversation>,
+    entries: Vec<LogEntry>,
+}
+
+#[derive(Default)]
+struct CodexParseState {
+    id: Option<String>,
+    cwd: Option<PathBuf>,
+    workspace_roots: Vec<PathBuf>,
+    model: Option<String>,
+    total_tokens: u64,
+    metadata_timestamp: Option<DateTime<FixedOffset>>,
+    first_timestamp: Option<DateTime<FixedOffset>>,
+    last_timestamp: Option<DateTime<FixedOffset>>,
+    entries: Vec<LogEntry>,
+    all_parts: Vec<String>,
+    preview_parts: Vec<String>,
+    message_count: usize,
+    parse_errors: Vec<ParseError>,
+}
+
+enum ConversationLoad {
+    Cached(Conversation),
+    Fresh(Conversation, SourceFingerprint),
+}
+
+impl ConversationLoad {
+    fn into_conversation(self) -> Conversation {
+        match self {
+            Self::Cached(conversation) | Self::Fresh(conversation, _) => conversation,
+        }
+    }
+}
+
+impl CodexProvider {
+    pub fn new() -> Self {
+        let codex_home = std::env::var_os("CODEX_HOME")
+            .map(PathBuf::from)
+            .or_else(|| home::home_dir().map(|home| home.join(".codex")))
+            .unwrap_or_default();
+        Self { codex_home }
+    }
+
+    fn sessions_root(&self) -> PathBuf {
+        self.codex_home.join("sessions")
+    }
+
+    fn load_all_conversations(
+        &self,
+        show_last: bool,
+        debug_level: Option<DebugLevel>,
+    ) -> Result<Vec<Conversation>> {
+        let root = self.sessions_root();
+        if !root.exists() {
+            return Ok(Vec::new());
+        }
+
+        let files = collect_session_files(&root);
+        let cache = load_provider_cache(ProviderKind::Codex, show_last);
+        let loaded: Vec<ConversationLoad> = files
+            .into_par_iter()
+            .filter_map(|path| {
+                let filename = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+                let metadata = fs::metadata(&path).ok();
+                let modified = metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.modified().ok());
+                let fingerprint = metadata.as_ref().map(fingerprint_from_metadata);
+
+                if let Some(fingerprint) = fingerprint
+                    && let Some(conversation) = cache
+                        .get(&path)
+                        .and_then(|cached| cached.conversation_if_fresh(fingerprint))
+                {
+                    debug::debug(
+                        debug_level,
+                        &format!("Loaded Codex transcript {} from index", filename),
+                    );
+                    return Some(ConversationLoad::Cached(conversation));
+                }
+
+                match process_codex_transcript_file(path, show_last, modified, debug_level) {
+                    Ok(Some(mut conversation)) => {
+                        debug::debug(
+                            debug_level,
+                            &format!(
+                                "Loaded Codex transcript {}: {}",
+                                filename, conversation.preview
+                            ),
+                        );
+                        attach_search_cache(&mut conversation);
+                        match fingerprint {
+                            Some(fingerprint) => {
+                                Some(ConversationLoad::Fresh(conversation, fingerprint))
+                            }
+                            None => Some(ConversationLoad::Cached(conversation)),
+                        }
+                    }
+                    Ok(None) => None,
+                    Err(err) => {
+                        debug::warn(
+                            debug_level,
+                            &format!("Failed to process Codex transcript {}: {}", filename, err),
+                        );
+                        None
+                    }
+                }
+            })
+            .collect();
+
+        save_conversations(
+            ProviderKind::Codex,
+            show_last,
+            loaded.iter().filter_map(|loaded| match loaded {
+                ConversationLoad::Fresh(conversation, fingerprint) => {
+                    Some((conversation, *fingerprint))
+                }
+                ConversationLoad::Cached(_) => None,
+            }),
+        );
+
+        let mut conversations: Vec<Conversation> = loaded
+            .into_iter()
+            .map(ConversationLoad::into_conversation)
+            .collect();
+        conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        for (idx, conversation) in conversations.iter_mut().enumerate() {
+            conversation.index = idx;
+        }
+        Ok(conversations)
+    }
+}
+
+impl super::Provider for CodexProvider {
+    fn kind(&self) -> ProviderKind {
+        ProviderKind::Codex
+    }
+
+    fn name(&self) -> &str {
+        "Codex"
+    }
+
+    fn detect(&self) -> bool {
+        self.sessions_root().exists()
+    }
+
+    fn load_conversations(
+        &self,
+        show_last: bool,
+        debug_level: Option<DebugLevel>,
+    ) -> Result<Vec<Conversation>> {
+        self.load_all_conversations(show_last, debug_level)
+    }
+
+    fn load_conversations_streaming(
+        &self,
+        show_last: bool,
+        debug_level: Option<DebugLevel>,
+    ) -> Receiver<LoaderMessage> {
+        let (tx, rx) = mpsc::channel();
+        let codex_home = self.codex_home.clone();
+
+        std::thread::spawn(move || {
+            let provider = CodexProvider { codex_home };
+            match provider.load_all_conversations(show_last, debug_level) {
+                Ok(conversations) => {
+                    if !conversations.is_empty() {
+                        let _ = tx.send(LoaderMessage::Batch(conversations));
+                    }
+                }
+                Err(_) => {
+                    let _ = tx.send(LoaderMessage::ProjectError);
+                }
+            }
+            let _ = tx.send(LoaderMessage::Done);
+        });
+
+        rx
+    }
+
+    fn read_entries(&self, conversation: &Conversation) -> Result<Vec<LogEntry>> {
+        Ok(parse_codex_transcript_file(&conversation.path, false, None, None)?.entries)
+    }
+
+    fn resume(&self, conversation: &Conversation, _default_args: &[String]) -> Result<()> {
+        let mut command = Command::new("codex");
+        command.arg("resume").arg(&conversation.id);
+        if let Some(project_path) = conversation
+            .project_path
+            .as_ref()
+            .or(conversation.cwd.as_ref())
+            .filter(|path| path.is_dir())
+        {
+            command.current_dir(project_path);
+        }
+
+        run_codex_command(command)
+    }
+
+    fn delete(&self, conversation: &Conversation) -> Result<()> {
+        let mut command = Command::new("codex");
+        command.arg("archive").arg(&conversation.id);
+        if let Some(project_path) = conversation
+            .project_path
+            .as_ref()
+            .or(conversation.cwd.as_ref())
+            .filter(|path| path.is_dir())
+        {
+            command.current_dir(project_path);
+        }
+
+        let status = command
+            .status()
+            .map_err(|err| AppError::ClaudeExecutionError(err.to_string()))?;
+        if !status.success() {
+            return Err(AppError::ClaudeExecutionError(format!(
+                "codex archive exited with status {}",
+                status
+            )));
+        }
+
+        delete_conversation(ProviderKind::Codex, &conversation.path);
+        Ok(())
+    }
+}
+
+fn process_codex_transcript_file(
+    path: PathBuf,
+    show_last: bool,
+    modified: Option<SystemTime>,
+    debug_level: Option<DebugLevel>,
+) -> Result<Option<Conversation>> {
+    Ok(parse_codex_transcript_file(&path, show_last, modified, debug_level)?.conversation)
+}
+
+fn parse_codex_transcript_file(
+    path: &Path,
+    show_last: bool,
+    modified: Option<SystemTime>,
+    debug_level: Option<DebugLevel>,
+) -> Result<ParsedCodexTranscript> {
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    parse_codex_transcript_reader(path.to_path_buf(), reader, show_last, modified, debug_level)
+}
+
+fn parse_codex_transcript_reader<R: BufRead>(
+    path: PathBuf,
+    reader: R,
+    show_last: bool,
+    modified: Option<SystemTime>,
+    debug_level: Option<DebugLevel>,
+) -> Result<ParsedCodexTranscript> {
+    let mut state = CodexParseState::default();
+    let filename = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    for (line_idx, line_result) in reader.lines().enumerate() {
+        let line = match line_result {
+            Ok(line) => line,
+            Err(err) => {
+                state.parse_errors.push(ParseError {
+                    line_number: line_idx + 1,
+                    line_content: String::new(),
+                    error_message: err.to_string(),
+                    context_before: Vec::new(),
+                    context_after: Vec::new(),
+                });
+                continue;
+            }
+        };
+
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        match serde_json::from_str::<Value>(&line) {
+            Ok(value) => process_codex_record(&mut state, &value, line_idx + 1),
+            Err(err) => {
+                debug::warn(
+                    debug_level,
+                    &format!(
+                        "Codex parse error in {} at line {}: {}",
+                        filename,
+                        line_idx + 1,
+                        err
+                    ),
+                );
+                state.parse_errors.push(ParseError {
+                    line_number: line_idx + 1,
+                    line_content: line,
+                    error_message: err.to_string(),
+                    context_before: Vec::new(),
+                    context_after: Vec::new(),
+                });
+            }
+        }
+    }
+
+    let entries = state.entries.clone();
+    let conversation = build_codex_conversation(path, show_last, modified, state);
+    Ok(ParsedCodexTranscript {
+        conversation,
+        entries,
+    })
+}
+
+fn process_codex_record(state: &mut CodexParseState, record: &Value, line_idx: usize) {
+    let timestamp = record_timestamp(record);
+    if let Some(timestamp) = timestamp {
+        update_timestamp_bounds(state, timestamp);
+    }
+
+    match record.get("type").and_then(Value::as_str) {
+        Some("session_meta") => {
+            if let Some(payload) = record.get("payload") {
+                parse_session_meta(state, payload);
+            }
+            return;
+        }
+        Some("turn_context") => {
+            if let Some(payload) = record.get("payload") {
+                parse_turn_context(state, payload);
+            }
+            return;
+        }
+        _ => {}
+    }
+
+    if is_legacy_session_metadata(record) {
+        parse_legacy_session_meta(state, record);
+        return;
+    }
+
+    let item = record.get("payload").unwrap_or(record);
+    match item.get("type").and_then(Value::as_str) {
+        Some("message") => process_message_item(state, item, timestamp),
+        Some("function_call") | Some("custom_tool_call") | Some("web_search_call") => {
+            process_tool_call_item(state, item, timestamp, line_idx)
+        }
+        Some("function_call_output") | Some("custom_tool_call_output") => {
+            process_tool_output_item(state, item, timestamp, line_idx)
+        }
+        Some("reasoning") => process_reasoning_item(state, item, timestamp, line_idx),
+        Some("token_count") => parse_token_count(state, item),
+        _ => {}
+    }
+}
+
+fn parse_session_meta(state: &mut CodexParseState, payload: &Value) {
+    if state.id.is_none() {
+        state.id = payload
+            .get("id")
+            .and_then(Value::as_str)
+            .map(ToString::to_string);
+    }
+    if state.cwd.is_none() {
+        state.cwd = payload
+            .get("cwd")
+            .and_then(Value::as_str)
+            .map(PathBuf::from);
+    }
+    if state.metadata_timestamp.is_none() {
+        state.metadata_timestamp = payload
+            .get("timestamp")
+            .and_then(Value::as_str)
+            .and_then(parse_timestamp);
+    }
+}
+
+fn parse_legacy_session_meta(state: &mut CodexParseState, record: &Value) {
+    if state.id.is_none() {
+        state.id = record
+            .get("id")
+            .and_then(Value::as_str)
+            .map(ToString::to_string);
+    }
+    if state.metadata_timestamp.is_none() {
+        state.metadata_timestamp = record
+            .get("timestamp")
+            .and_then(Value::as_str)
+            .and_then(parse_timestamp);
+    }
+}
+
+fn parse_turn_context(state: &mut CodexParseState, payload: &Value) {
+    if state.cwd.is_none() {
+        state.cwd = payload
+            .get("cwd")
+            .and_then(Value::as_str)
+            .map(PathBuf::from);
+    }
+    if state.workspace_roots.is_empty()
+        && let Some(roots) = payload.get("workspace_roots").and_then(Value::as_array)
+    {
+        state.workspace_roots = roots
+            .iter()
+            .filter_map(Value::as_str)
+            .map(PathBuf::from)
+            .collect();
+    }
+    if state.model.is_none() {
+        state.model = payload
+            .get("model")
+            .and_then(Value::as_str)
+            .map(ToString::to_string);
+    }
+}
+
+fn process_message_item(
+    state: &mut CodexParseState,
+    item: &Value,
+    timestamp: Option<DateTime<FixedOffset>>,
+) {
+    let role = item.get("role").and_then(Value::as_str).unwrap_or_default();
+    if role != "user" && role != "assistant" {
+        return;
+    }
+
+    let blocks = text_blocks_from_codex_content(item.get("content"), role == "user");
+    if blocks.is_empty() {
+        return;
+    }
+
+    let text = extract_text_from_content_blocks(&blocks);
+    if text.trim().is_empty() {
+        return;
+    }
+
+    let timestamp = timestamp_string(timestamp, state.metadata_timestamp);
+    let uuid = item
+        .get("id")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+
+    match role {
+        "user" => state.entries.push(LogEntry::User {
+            message: UserMessage {
+                role: "user".to_string(),
+                content: UserContent::Blocks(blocks),
+            },
+            timestamp,
+            uuid,
+            cwd: state
+                .cwd
+                .as_ref()
+                .map(|path| path.to_string_lossy().to_string()),
+        }),
+        "assistant" => state.entries.push(LogEntry::Assistant {
+            message: AssistantMessage {
+                role: "assistant".to_string(),
+                content: blocks,
+                model: state.model.clone(),
+                usage: None,
+                id: uuid,
+            },
+            timestamp,
+            uuid: None,
+        }),
+        _ => {}
+    }
+
+    state.all_parts.push(text.clone());
+    state.preview_parts.push(text);
+    state.message_count += 1;
+}
+
+fn process_tool_call_item(
+    state: &mut CodexParseState,
+    item: &Value,
+    timestamp: Option<DateTime<FixedOffset>>,
+    line_idx: usize,
+) {
+    let name = item
+        .get("name")
+        .or_else(|| item.get("tool_name"))
+        .and_then(Value::as_str)
+        .unwrap_or("tool")
+        .to_string();
+    let id = item
+        .get("call_id")
+        .or_else(|| item.get("id"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .unwrap_or_else(|| format!("codex-call-{}", line_idx));
+    let input = parse_tool_input(item);
+    let timestamp = timestamp_string(timestamp, state.metadata_timestamp);
+
+    state.entries.push(LogEntry::Assistant {
+        message: AssistantMessage {
+            role: "assistant".to_string(),
+            content: vec![ContentBlock::ToolUse { id, name, input }],
+            model: state.model.clone(),
+            usage: None,
+            id: None,
+        },
+        timestamp,
+        uuid: None,
+    });
+}
+
+fn process_tool_output_item(
+    state: &mut CodexParseState,
+    item: &Value,
+    timestamp: Option<DateTime<FixedOffset>>,
+    line_idx: usize,
+) {
+    let tool_use_id = item
+        .get("call_id")
+        .or_else(|| item.get("id"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .unwrap_or_else(|| format!("codex-result-{}", line_idx));
+    let content = item
+        .get("output")
+        .or_else(|| item.get("result"))
+        .cloned()
+        .or(Some(Value::Null));
+    let timestamp = timestamp_string(timestamp, state.metadata_timestamp);
+
+    state.entries.push(LogEntry::User {
+        message: UserMessage {
+            role: "user".to_string(),
+            content: UserContent::Blocks(vec![ContentBlock::ToolResult {
+                tool_use_id,
+                content,
+            }]),
+        },
+        timestamp,
+        uuid: None,
+        cwd: state
+            .cwd
+            .as_ref()
+            .map(|path| path.to_string_lossy().to_string()),
+    });
+}
+
+fn process_reasoning_item(
+    state: &mut CodexParseState,
+    item: &Value,
+    timestamp: Option<DateTime<FixedOffset>>,
+    line_idx: usize,
+) {
+    let Some(summary) = item
+        .get("summary")
+        .and_then(text_from_codex_content)
+        .filter(|summary| !summary.trim().is_empty())
+    else {
+        return;
+    };
+    let timestamp = timestamp_string(timestamp, state.metadata_timestamp);
+
+    state.entries.push(LogEntry::Assistant {
+        message: AssistantMessage {
+            role: "assistant".to_string(),
+            content: vec![ContentBlock::Thinking {
+                thinking: summary,
+                signature: format!("codex-thinking-{}", line_idx),
+            }],
+            model: state.model.clone(),
+            usage: None,
+            id: None,
+        },
+        timestamp,
+        uuid: None,
+    });
+}
+
+fn parse_token_count(state: &mut CodexParseState, item: &Value) {
+    if let Some(total_tokens) = item
+        .pointer("/info/total_token_usage/total_tokens")
+        .and_then(Value::as_u64)
+    {
+        state.total_tokens = total_tokens;
+    }
+}
+
+fn build_codex_conversation(
+    path: PathBuf,
+    show_last: bool,
+    modified: Option<SystemTime>,
+    state: CodexParseState,
+) -> Option<Conversation> {
+    if state.preview_parts.is_empty() {
+        return None;
+    }
+
+    let preview = if show_last {
+        state
+            .preview_parts
+            .iter()
+            .rev()
+            .take(3)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(" ... ")
+    } else {
+        state
+            .preview_parts
+            .iter()
+            .take(3)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(" ... ")
+    };
+
+    let timestamp = state
+        .last_timestamp
+        .or(state.metadata_timestamp)
+        .map(|timestamp| timestamp.with_timezone(&Local))
+        .or_else(|| modified.map(DateTime::<Local>::from))
+        .unwrap_or_else(Local::now);
+    let duration_minutes = match (state.first_timestamp, state.last_timestamp) {
+        (Some(first), Some(last)) => {
+            let minutes = last.signed_duration_since(first).num_minutes();
+            (minutes > 0).then_some(minutes as u64)
+        }
+        _ => None,
+    };
+    let project_path = state
+        .cwd
+        .or_else(|| state.workspace_roots.into_iter().next());
+    let project_name = project_path
+        .as_ref()
+        .map(|path| format_short_name_from_path(path));
+    let id = state
+        .id
+        .unwrap_or_else(|| session_id_from_path(&path).unwrap_or_else(|| "unknown".to_string()));
+
+    Some(Conversation {
+        path,
+        index: 0,
+        provider: ProviderKind::Codex,
+        id,
+        timestamp,
+        preview: normalize_whitespace(&preview),
+        full_text: normalize_whitespace(&state.all_parts.join(" ")),
+        project_name,
+        project_path: project_path.clone(),
+        cwd: project_path,
+        message_count: state.message_count,
+        parse_errors: state.parse_errors,
+        summary: None,
+        model: state.model,
+        total_tokens: state.total_tokens,
+        duration_minutes,
+        search_text_lower: None,
+        search_topic_end: None,
+    })
+}
+
+fn collect_session_files(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut dirs = vec![root.to_path_buf()];
+
+    while let Some(dir) = dirs.pop() {
+        let entries = match fs::read_dir(&dir) {
+            Ok(entries) => entries,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                dirs.push(path);
+            } else if path.is_file() && path.extension().is_some_and(|ext| ext == "jsonl") {
+                files.push(path);
+            }
+        }
+    }
+
+    files.sort_by_key(|path| {
+        std::cmp::Reverse(
+            fs::metadata(path)
+                .and_then(|metadata| metadata.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH),
+        )
+    });
+    files
+}
+
+fn text_blocks_from_codex_content(
+    content: Option<&Value>,
+    filter_metadata: bool,
+) -> Vec<ContentBlock> {
+    match content {
+        Some(Value::Array(blocks)) => blocks
+            .iter()
+            .filter_map(|block| {
+                let text = block.get("text").and_then(Value::as_str)?;
+                if filter_metadata && is_codex_metadata_text(text) {
+                    return None;
+                }
+                Some(ContentBlock::Text {
+                    text: text.to_string(),
+                })
+            })
+            .collect(),
+        Some(Value::String(text)) if !(filter_metadata && is_codex_metadata_text(text)) => {
+            vec![ContentBlock::Text { text: text.clone() }]
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn text_from_codex_content(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => Some(text.clone()),
+        Value::Array(items) => {
+            let text = items
+                .iter()
+                .filter_map(|item| item.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            (!text.is_empty()).then_some(text)
+        }
+        Value::Object(_) => value
+            .get("text")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        _ => None,
+    }
+}
+
+fn extract_text_from_content_blocks(blocks: &[ContentBlock]) -> String {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text { text } => Some(text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn parse_tool_input(item: &Value) -> Value {
+    let Some(input) = item.get("arguments").or_else(|| item.get("input")) else {
+        return Value::Null;
+    };
+
+    match input {
+        Value::String(text) => {
+            serde_json::from_str(text).unwrap_or_else(|_| Value::String(text.clone()))
+        }
+        value => value.clone(),
+    }
+}
+
+fn record_timestamp(record: &Value) -> Option<DateTime<FixedOffset>> {
+    record
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .and_then(parse_timestamp)
+}
+
+fn parse_timestamp(value: &str) -> Option<DateTime<FixedOffset>> {
+    DateTime::parse_from_rfc3339(value).ok()
+}
+
+fn update_timestamp_bounds(state: &mut CodexParseState, timestamp: DateTime<FixedOffset>) {
+    if state.first_timestamp.is_none() {
+        state.first_timestamp = Some(timestamp);
+    }
+    state.last_timestamp = Some(timestamp);
+}
+
+fn timestamp_string(
+    timestamp: Option<DateTime<FixedOffset>>,
+    fallback: Option<DateTime<FixedOffset>>,
+) -> String {
+    timestamp
+        .or(fallback)
+        .map(|ts| ts.to_rfc3339())
+        .unwrap_or_default()
+}
+
+fn is_legacy_session_metadata(record: &Value) -> bool {
+    record.get("id").is_some()
+        && record.get("timestamp").is_some()
+        && record.get("type").is_none()
+        && record.get("payload").is_none()
+}
+
+fn is_codex_metadata_text(text: &str) -> bool {
+    let trimmed = text.trim_start();
+    trimmed.starts_with("# AGENTS.md instructions for ")
+        || trimmed.starts_with("<environment_context>")
+        || trimmed.contains("\n<environment_context>")
+}
+
+fn session_id_from_path(path: &Path) -> Option<String> {
+    let stem = path.file_stem()?.to_str()?;
+    if stem.len() >= 36 {
+        let candidate = &stem[stem.len() - 36..];
+        if is_uuid_like(candidate) {
+            return Some(candidate.to_string());
+        }
+    }
+    Some(stem.to_string())
+}
+
+fn is_uuid_like(value: &str) -> bool {
+    value.len() == 36 && value.chars().all(|ch| ch.is_ascii_hexdigit() || ch == '-')
+}
+
+fn normalize_whitespace(input: &str) -> String {
+    input.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(unix)]
+fn run_codex_command(mut command: Command) -> Result<()> {
+    use std::os::unix::process::CommandExt;
+    let err = command.exec();
+    Err(AppError::ClaudeExecutionError(err.to_string()))
+}
+
+#[cfg(not(unix))]
+fn run_codex_command(mut command: Command) -> Result<()> {
+    let status = command
+        .status()
+        .map_err(|err| AppError::ClaudeExecutionError(err.to_string()))?;
+
+    if !status.success() {
+        return Err(AppError::ClaudeExecutionError(format!(
+            "codex CLI exited with status {}",
+            status
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn parse(content: &str, show_last: bool) -> ParsedCodexTranscript {
+        parse_codex_transcript_reader(
+            PathBuf::from("rollout-2026-06-10T17-58-01-019eb42f-a4e2-75e0-b7ad-2268948a559c.jsonl"),
+            Cursor::new(content),
+            show_last,
+            None,
+            None,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn parses_current_codex_transcript() {
+        let content = [
+            r#"{"timestamp":"2026-06-11T00:58:16.810Z","type":"session_meta","payload":{"id":"019eb42f-a4e2-75e0-b7ad-2268948a559c","timestamp":"2026-06-11T00:58:01.875Z","cwd":"/tmp/project","source":"cli"}}"#,
+            r#"{"timestamp":"2026-06-11T00:58:16.812Z","type":"turn_context","payload":{"cwd":"/tmp/project","workspace_roots":["/tmp/project"],"model":"gpt-5.5"}}"#,
+            r#"{"timestamp":"2026-06-11T00:58:16.813Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>\nnoise\n</environment_context>"},{"type":"input_text","text":"Build Codex support"}]}}"#,
+            r#"{"timestamp":"2026-06-11T00:58:27.514Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Working on it"}],"phase":"commentary"}}"#,
+            r#"{"timestamp":"2026-06-11T00:58:27.515Z","type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\"cmd\":\"cargo test\"}","call_id":"call_1"}}"#,
+            r#"{"timestamp":"2026-06-11T00:58:27.714Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call_1","output":"ok"}}"#,
+            r#"{"timestamp":"2026-06-11T00:58:27.714Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"total_tokens":1234}}}}"#,
+        ]
+        .join("\n");
+
+        let parsed = parse(&content, false);
+        let conversation = parsed.conversation.unwrap();
+
+        assert_eq!(conversation.provider, ProviderKind::Codex);
+        assert_eq!(conversation.id, "019eb42f-a4e2-75e0-b7ad-2268948a559c");
+        assert_eq!(
+            conversation.project_path,
+            Some(PathBuf::from("/tmp/project"))
+        );
+        assert_eq!(conversation.model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(conversation.total_tokens, 1234);
+        assert_eq!(conversation.message_count, 2);
+        assert!(conversation.preview.contains("Build Codex support"));
+        assert!(!conversation.preview.contains("environment_context"));
+        assert_eq!(parsed.entries.len(), 4);
+    }
+
+    #[test]
+    fn parses_legacy_codex_transcript() {
+        let content = [
+            r#"{"id":"a4bcd2da-17d7-430a-b2e2-3fc80e1ac920","timestamp":"2025-08-31T21:41:00.914Z","instructions":"test"}"#,
+            r#"{"record_type":"response_item"}"#,
+            r#"{"type":"message","id":"msg_1","role":"user","content":[{"type":"input_text","text":"Hello Codex"}]}"#,
+            r#"{"type":"reasoning","id":"rs_1","summary":[{"type":"summary_text","text":"Thinking summary"}],"encrypted_content":"..."}"#,
+            r#"{"type":"message","id":"msg_2","role":"assistant","content":[{"type":"output_text","text":"Hello back"}]}"#,
+            r#"{"type":"function_call","id":"fc_1","name":"shell","arguments":"{\"command\":\"pwd\"}","call_id":"call_1"}"#,
+            r#"{"type":"function_call_output","call_id":"call_1","output":"/tmp"}"#,
+        ]
+        .join("\n");
+
+        let parsed = parse(&content, true);
+        let conversation = parsed.conversation.unwrap();
+
+        assert_eq!(conversation.id, "a4bcd2da-17d7-430a-b2e2-3fc80e1ac920");
+        assert!(conversation.preview.starts_with("Hello back"));
+        assert_eq!(conversation.message_count, 2);
+        assert_eq!(parsed.entries.len(), 5);
+    }
+
+    #[test]
+    fn extracts_session_id_from_rollout_filename() {
+        let path =
+            PathBuf::from("rollout-2026-06-10T17-58-01-019eb42f-a4e2-75e0-b7ad-2268948a559c.jsonl");
+
+        assert_eq!(
+            session_id_from_path(&path).as_deref(),
+            Some("019eb42f-a4e2-75e0-b7ad-2268948a559c")
+        );
+    }
+}

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -12,6 +12,7 @@ use crate::history::{
 use chrono::{DateTime, FixedOffset, Local};
 use rayon::prelude::*;
 use serde_json::Value;
+use std::ffi::OsString;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -40,7 +41,6 @@ struct CodexParseState {
     last_timestamp: Option<DateTime<FixedOffset>>,
     entries: Vec<LogEntry>,
     all_parts: Vec<String>,
-    preview_parts: Vec<String>,
     message_count: usize,
     parse_errors: Vec<ParseError>,
 }
@@ -60,15 +60,16 @@ impl ConversationLoad {
 
 impl CodexProvider {
     pub fn new() -> Self {
-        let codex_home = std::env::var_os("CODEX_HOME")
-            .map(PathBuf::from)
-            .or_else(|| home::home_dir().map(|home| home.join(".codex")))
-            .unwrap_or_default();
-        Self { codex_home }
+        Self {
+            codex_home: resolve_codex_home(std::env::var_os("CODEX_HOME"), home::home_dir()),
+        }
     }
 
-    fn sessions_root(&self) -> PathBuf {
-        self.codex_home.join("sessions")
+    fn sessions_root(&self) -> Option<PathBuf> {
+        if self.codex_home.as_os_str().is_empty() {
+            return None;
+        }
+        Some(self.codex_home.join("sessions"))
     }
 
     fn load_all_conversations(
@@ -76,7 +77,9 @@ impl CodexProvider {
         show_last: bool,
         debug_level: Option<DebugLevel>,
     ) -> Result<Vec<Conversation>> {
-        let root = self.sessions_root();
+        let Some(root) = self.sessions_root() else {
+            return Ok(Vec::new());
+        };
         if !root.exists() {
             return Ok(Vec::new());
         }
@@ -171,7 +174,7 @@ impl super::Provider for CodexProvider {
     }
 
     fn detect(&self) -> bool {
-        self.sessions_root().exists()
+        self.sessions_root().is_some_and(|root| root.exists())
     }
 
     fn load_conversations(
@@ -215,13 +218,23 @@ impl super::Provider for CodexProvider {
     fn resume(&self, conversation: &Conversation, _default_args: &[String]) -> Result<()> {
         let mut command = Command::new("codex");
         command.arg("resume").arg(&conversation.id);
-        if let Some(project_path) = conversation
+        // Legacy transcripts may record no cwd at all; codex can still resume those
+        // by id, so only a recorded-but-missing directory is an error.
+        match conversation
             .project_path
             .as_ref()
             .or(conversation.cwd.as_ref())
-            .filter(|path| path.is_dir())
         {
-            command.current_dir(project_path);
+            Some(path) if path.is_dir() => {
+                command.current_dir(path);
+            }
+            Some(path) => {
+                return Err(AppError::ClaudeExecutionError(format!(
+                    "Project directory no longer exists: {}",
+                    path.display()
+                )));
+            }
+            None => {}
         }
 
         run_codex_command(command)
@@ -239,13 +252,17 @@ impl super::Provider for CodexProvider {
             command.current_dir(project_path);
         }
 
-        let status = command
-            .status()
+        // Capture output: this runs inside the live TUI (raw mode + alternate
+        // screen), so the child must not inherit the terminal.
+        let output = command
+            .output()
             .map_err(|err| AppError::ClaudeExecutionError(err.to_string()))?;
-        if !status.success() {
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(AppError::ClaudeExecutionError(format!(
-                "codex archive exited with status {}",
-                status
+                "codex archive exited with status {}: {}",
+                output.status,
+                stderr.trim()
             )));
         }
 
@@ -330,7 +347,7 @@ fn parse_codex_transcript_reader<R: BufRead>(
         }
     }
 
-    let entries = state.entries.clone();
+    let entries = std::mem::take(&mut state.entries);
     let conversation = build_codex_conversation(path, show_last, modified, state);
     Ok(ParsedCodexTranscript {
         conversation,
@@ -368,9 +385,10 @@ fn process_codex_record(state: &mut CodexParseState, record: &Value, line_idx: u
     let item = record.get("payload").unwrap_or(record);
     match item.get("type").and_then(Value::as_str) {
         Some("message") => process_message_item(state, item, timestamp),
-        Some("function_call") | Some("custom_tool_call") | Some("web_search_call") => {
+        Some("function_call") | Some("custom_tool_call") => {
             process_tool_call_item(state, item, timestamp, line_idx)
         }
+        Some("web_search_call") => process_web_search_item(state, item, timestamp, line_idx),
         Some("function_call_output") | Some("custom_tool_call_output") => {
             process_tool_output_item(state, item, timestamp, line_idx)
         }
@@ -493,8 +511,7 @@ fn process_message_item(
         _ => {}
     }
 
-    state.all_parts.push(text.clone());
-    state.preview_parts.push(text);
+    state.all_parts.push(text);
     state.message_count += 1;
 }
 
@@ -510,13 +527,61 @@ fn process_tool_call_item(
         .and_then(Value::as_str)
         .unwrap_or("tool")
         .to_string();
+    let input = parse_tool_input(item);
+    push_tool_call_entry(state, item, name, input, timestamp, line_idx);
+}
+
+// web_search_call items carry the request in `action` ({type: search|open_page,
+// query/queries/url}) instead of `arguments`; map them onto the web_search /
+// web_fetch formatters.
+fn process_web_search_item(
+    state: &mut CodexParseState,
+    item: &Value,
+    timestamp: Option<DateTime<FixedOffset>>,
+    line_idx: usize,
+) {
+    let action = item.get("action").unwrap_or(&Value::Null);
+    let query = action
+        .get("query")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .or_else(|| {
+            action
+                .get("queries")
+                .and_then(Value::as_array)
+                .map(|queries| {
+                    queries
+                        .iter()
+                        .filter_map(Value::as_str)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                })
+        })
+        .filter(|query| !query.is_empty());
+    let url = action.get("url").and_then(Value::as_str);
+
+    let (name, input) = match (query, url) {
+        (Some(query), _) => ("web_search", serde_json::json!({ "query": query })),
+        (None, Some(url)) => ("web_fetch", serde_json::json!({ "url": url })),
+        (None, None) => ("web_search", action.clone()),
+    };
+    push_tool_call_entry(state, item, name.to_string(), input, timestamp, line_idx);
+}
+
+fn push_tool_call_entry(
+    state: &mut CodexParseState,
+    item: &Value,
+    name: String,
+    input: Value,
+    timestamp: Option<DateTime<FixedOffset>>,
+    line_idx: usize,
+) {
     let id = item
         .get("call_id")
         .or_else(|| item.get("id"))
         .and_then(Value::as_str)
         .map(ToString::to_string)
         .unwrap_or_else(|| format!("codex-call-{}", line_idx));
-    let input = parse_tool_input(item);
     let timestamp = timestamp_string(timestamp, state.metadata_timestamp);
 
     state.entries.push(LogEntry::Assistant {
@@ -614,13 +679,13 @@ fn build_codex_conversation(
     modified: Option<SystemTime>,
     state: CodexParseState,
 ) -> Option<Conversation> {
-    if state.preview_parts.is_empty() {
+    if state.all_parts.is_empty() {
         return None;
     }
 
     let preview = if show_last {
         state
-            .preview_parts
+            .all_parts
             .iter()
             .rev()
             .take(3)
@@ -629,7 +694,7 @@ fn build_codex_conversation(
             .join(" ... ")
     } else {
         state
-            .preview_parts
+            .all_parts
             .iter()
             .take(3)
             .cloned()
@@ -693,7 +758,10 @@ fn collect_session_files(root: &Path) -> Vec<PathBuf> {
         };
         for entry in entries.flatten() {
             let path = entry.path();
-            if path.is_dir() {
+            // file_type() does not follow symlinks, so symlinked directories are
+            // never descended (guards against cycles); symlinked files still
+            // resolve through path.is_file().
+            if entry.file_type().is_ok_and(|file_type| file_type.is_dir()) {
                 dirs.push(path);
             } else if path.is_file() && path.extension().is_some_and(|ext| ext == "jsonl") {
                 files.push(path);
@@ -701,14 +769,16 @@ fn collect_session_files(root: &Path) -> Vec<PathBuf> {
         }
     }
 
-    files.sort_by_key(|path| {
-        std::cmp::Reverse(
-            fs::metadata(path)
-                .and_then(|metadata| metadata.modified())
-                .unwrap_or(SystemTime::UNIX_EPOCH),
-        )
-    });
     files
+}
+
+fn resolve_codex_home(env_value: Option<OsString>, home: Option<PathBuf>) -> PathBuf {
+    env_value
+        // codex itself treats a set-but-empty CODEX_HOME as unset.
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| home.map(|home| home.join(".codex")))
+        .unwrap_or_default()
 }
 
 fn text_blocks_from_codex_content(
@@ -813,16 +883,21 @@ fn is_legacy_session_metadata(record: &Value) -> bool {
         && record.get("payload").is_none()
 }
 
+// Matches synthetic user-role records codex injects (instructions, environment
+// snapshots, Esc-interrupt markers). These always START with their marker;
+// matching anywhere in the text would eat genuine user messages that quote one.
 fn is_codex_metadata_text(text: &str) -> bool {
     let trimmed = text.trim_start();
     trimmed.starts_with("# AGENTS.md instructions for ")
         || trimmed.starts_with("<environment_context>")
-        || trimmed.contains("\n<environment_context>")
+        || trimmed.starts_with("<turn_aborted>")
 }
 
 fn session_id_from_path(path: &Path) -> Option<String> {
     let stem = path.file_stem()?.to_str()?;
-    if stem.len() >= 36 {
+    // A UUID suffix is pure ASCII, so a non-char-boundary cut point (multi-byte
+    // character straddling it) can never hold one; slicing there would panic.
+    if stem.len() >= 36 && stem.is_char_boundary(stem.len() - 36) {
         let candidate = &stem[stem.len() - 36..];
         if is_uuid_like(candidate) {
             return Some(candidate.to_string());
@@ -939,5 +1014,104 @@ mod tests {
             session_id_from_path(&path).as_deref(),
             Some("019eb42f-a4e2-75e0-b7ad-2268948a559c")
         );
+    }
+
+    #[test]
+    fn filters_turn_aborted_but_keeps_users_quoting_metadata_tags() {
+        let content = [
+            r#"{"timestamp":"2026-06-11T00:58:16.813Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"<turn_aborted>\nThe user interrupted the previous turn on purpose."}]}}"#,
+            r#"{"timestamp":"2026-06-11T00:58:20.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"why does codex inject this?\n<environment_context>\nnoise\n</environment_context>"}]}}"#,
+        ]
+        .join("\n");
+
+        let parsed = parse(&content, false);
+        let conversation = parsed.conversation.unwrap();
+
+        assert!(!conversation.full_text.contains("turn_aborted"));
+        assert!(
+            conversation
+                .full_text
+                .contains("why does codex inject this?")
+        );
+        assert_eq!(conversation.message_count, 1);
+        assert_eq!(parsed.entries.len(), 1);
+    }
+
+    #[test]
+    fn maps_web_search_calls_to_named_tool_entries() {
+        let content = [
+            r#"{"timestamp":"2026-06-11T00:58:16.813Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Search the docs"}]}}"#,
+            r#"{"timestamp":"2026-06-11T00:58:17.000Z","type":"response_item","payload":{"type":"web_search_call","status":"completed","action":{"type":"search","query":"codex config reference"}}}"#,
+            r#"{"timestamp":"2026-06-11T00:58:18.000Z","type":"response_item","payload":{"type":"web_search_call","status":"completed","action":{"type":"open_page","url":"https://example.com/docs"}}}"#,
+        ]
+        .join("\n");
+
+        let parsed = parse(&content, false);
+        let tool_uses: Vec<(&str, &Value)> = parsed
+            .entries
+            .iter()
+            .filter_map(|entry| match entry {
+                LogEntry::Assistant { message, .. } => match message.content.first() {
+                    Some(ContentBlock::ToolUse { name, input, .. }) => Some((name.as_str(), input)),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(tool_uses.len(), 2);
+        assert_eq!(tool_uses[0].0, "web_search");
+        assert_eq!(
+            tool_uses[0].1.get("query").and_then(Value::as_str),
+            Some("codex config reference")
+        );
+        assert_eq!(tool_uses[1].0, "web_fetch");
+        assert_eq!(
+            tool_uses[1].1.get("url").and_then(Value::as_str),
+            Some("https://example.com/docs")
+        );
+    }
+
+    #[test]
+    fn session_id_handles_non_ascii_filenames() {
+        // 37-byte stem whose 36-bytes-from-the-end cut point lands inside 'é'.
+        let straddling = PathBuf::from(format!("é{}.jsonl", "a".repeat(35)));
+        let expected = format!("é{}", "a".repeat(35));
+        assert_eq!(
+            session_id_from_path(&straddling).as_deref(),
+            Some(expected.as_str())
+        );
+
+        let uuid_after_multibyte_prefix = PathBuf::from(
+            "日本語-rollout-2026-06-10T17-58-01-019eb42f-a4e2-75e0-b7ad-2268948a559c.jsonl",
+        );
+        assert_eq!(
+            session_id_from_path(&uuid_after_multibyte_prefix).as_deref(),
+            Some("019eb42f-a4e2-75e0-b7ad-2268948a559c")
+        );
+    }
+
+    #[test]
+    fn resolves_codex_home_treating_empty_env_as_unset() {
+        let home = Some(PathBuf::from("/home/user"));
+
+        assert_eq!(
+            resolve_codex_home(Some(OsString::from("/custom/codex")), home.clone()),
+            PathBuf::from("/custom/codex")
+        );
+        assert_eq!(
+            resolve_codex_home(Some(OsString::new()), home.clone()),
+            PathBuf::from("/home/user/.codex")
+        );
+        assert_eq!(
+            resolve_codex_home(None, home),
+            PathBuf::from("/home/user/.codex")
+        );
+        assert_eq!(resolve_codex_home(None, None), PathBuf::new());
+
+        let provider = CodexProvider {
+            codex_home: PathBuf::new(),
+        };
+        assert!(provider.sessions_root().is_none());
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -1,4 +1,5 @@
 pub mod claude;
+pub mod codex;
 pub mod cursor;
 pub mod cursor_agent;
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 fn provider_theme(kind: &ProviderKind) -> (String, (u8, u8, u8), (u8, u8, u8)) {
     match kind {
         ProviderKind::Claude => ("Claude".to_string(), (218, 119, 86), (170, 93, 67)),
+        ProviderKind::Codex => ("Codex".to_string(), (78, 201, 176), (56, 150, 132)),
         ProviderKind::Cursor => ("Cursor IDE".to_string(), (180, 130, 230), (140, 100, 180)),
         ProviderKind::CursorAgent => ("Cursor Agent".to_string(), (94, 184, 255), (72, 140, 194)),
     }
@@ -737,6 +738,7 @@ impl App {
         let conv = self.conversations.iter().find(|c| c.path == path);
 
         let assistant_label = match conv.map(|c| &c.provider) {
+            Some(ProviderKind::Codex) => "Codex",
             Some(ProviderKind::Cursor) => "Cursor",
             Some(ProviderKind::CursorAgent) => "Cursor Agent",
             _ => "Claude",

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -94,6 +94,7 @@ fn format_tokens_long(tokens: u64) -> String {
 fn provider_badge_text(provider: ProviderKind) -> &'static str {
     match provider {
         ProviderKind::Claude => "[Claude] ",
+        ProviderKind::Codex => "[Codex] ",
         ProviderKind::Cursor => "[Cursor] ",
         ProviderKind::CursorAgent => "[Cursor CLI] ",
     }
@@ -102,6 +103,7 @@ fn provider_badge_text(provider: ProviderKind) -> &'static str {
 fn provider_badge(provider: ProviderKind) -> Span<'static> {
     let color = match provider {
         ProviderKind::Claude => Color::Rgb(218, 119, 86), // Claude terracotta
+        ProviderKind::Codex => Color::Rgb(78, 201, 176),  // Codex teal
         ProviderKind::Cursor => Color::Rgb(180, 130, 230), // Cursor purple
         ProviderKind::CursorAgent => Color::Rgb(94, 184, 255), // Cursor agent blue
     };


### PR DESCRIPTION
## Summary

Adds Codex as a conversation history provider:

- Scans JSONL rollouts under `$CODEX_HOME/sessions/` (default `~/.codex/sessions/`), supporting both the current envelope format (`session_meta` / `turn_context` / `response_item` / `event_msg`) and the legacy flat format
- Lists, searches, and views Codex conversations alongside the other providers, including model, token totals, duration, and project attribution (cwd / workspace roots)
- Maps messages, tool calls/outputs, reasoning summaries, and web searches onto the existing viewer blocks (`web_search_call` actions render through the web_search/web_fetch formatters)
- Filters codex-injected noise (`<environment_context>`, AGENTS.md instructions, `<turn_aborted>` interrupt markers) from previews, search text, and the viewer
- Resume via `codex resume <session-id>` from the recorded project directory; delete via `codex archive <session-id>` (output captured so the TUI screen is never corrupted)
- Integrates with the SQLite conversation index cache like the other providers
- TUI integration: provider badge, theme color, and assistant label

## Hardening

The second commit addresses findings from a deep review of the initial implementation:

- Metadata tags are matched only at text start, so user messages quoting a tag are kept
- `session_id_from_path` no longer panics on non-ASCII filenames (char-boundary guard)
- A set-but-empty `CODEX_HOME` is treated as unset, matching codex-rs; loading is skipped entirely when no home can be resolved (previously a relative `sessions` dir in the CWD could be scanned)
- Directory symlinks are not followed when collecting session files (cycle guard); dropped an unused mtime sort that issued O(n log n) stat calls
- Parse no longer clones the full entry vec per file; removed a duplicate preview buffer
- `resume()` errors when the recorded project directory no longer exists, matching the Claude provider

## Testing

- `cargo test`: 171 passing (7 Codex-specific: current + legacy format parsing, metadata filtering, web_search_call mapping, non-ASCII filenames, CODEX_HOME resolution, rollout filename ID extraction)
- `cargo clippy --all-targets`: no warnings in the new code
- Parsing shapes validated against real `~/.codex/sessions` transcripts (2025-08 legacy through 2026-06 current) and codex-cli 0.139 (`resume`/`archive` subcommands)