### PR TITLE
Make startup loading subsecond

### DIFF
--- a/src/claude.rs
+++ b/src/claude.rs
@@ -53,6 +53,12 @@ pub enum LogEntry {
         #[serde(flatten)]
         extra: serde_json::Value,
     },
+    /// Entry types this version doesn't understand (attachment, ai-title,
+    /// queue-operation, ...). Newer Claude Code builds keep introducing types;
+    /// treating them as parse errors used to record megabytes of line content
+    /// and context per file.
+    #[serde(other)]
+    Unknown,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -147,6 +147,10 @@ pub struct Args {
     #[arg(long, help = "Disable colored output")]
     pub no_color: bool,
 
+    /// Benchmark startup loading (headless) and exit
+    #[arg(long, hide = true)]
+    pub bench_startup: bool,
+
     /// Input JSONL file to view directly (skips conversation selection)
     #[arg(
         value_name = "FILE",

--- a/src/conversation_index.rs
+++ b/src/conversation_index.rs
@@ -4,7 +4,6 @@
 //! JSONL transcripts and to reuse lowercased search text on warm starts.
 
 use crate::history::{Conversation, ProviderKind};
-use crate::tui::search::{normalize_for_search, topic_end_for_text};
 use chrono::{DateTime, Local};
 use rusqlite::{Connection, params};
 use std::collections::HashMap;
@@ -27,8 +26,12 @@ pub struct CachedFileConversation {
 }
 
 impl CachedFileConversation {
-    pub fn conversation_if_fresh(&self, fingerprint: SourceFingerprint) -> Option<Conversation> {
-        (self.fingerprint == fingerprint).then(|| self.conversation.clone())
+    /// Consume the cache entry, returning the conversation when the source file
+    /// is unchanged. Moving (rather than cloning) matters: cached entries carry
+    /// the full conversation text twice (original + lowercased).
+    pub fn into_conversation_if_fresh(self, fingerprint: SourceFingerprint) -> Option<Conversation> {
+        let fresh = self.fingerprint == fingerprint;
+        fresh.then_some(self.conversation)
     }
 }
 
@@ -36,18 +39,6 @@ pub fn fingerprint_from_metadata(metadata: &Metadata) -> SourceFingerprint {
     SourceFingerprint {
         modified_millis: system_time_to_millis(metadata.modified().unwrap_or(UNIX_EPOCH)),
         size: metadata.len().min(i64::MAX as u64) as i64,
-    }
-}
-
-pub fn attach_search_cache(conversation: &mut Conversation) {
-    if conversation.search_text_lower.is_none() {
-        conversation.search_text_lower = Some(normalize_for_search(&conversation.full_text));
-    }
-
-    if conversation.search_topic_end.is_none()
-        && let Some(text_lower) = &conversation.search_text_lower
-    {
-        conversation.search_topic_end = Some(topic_end_for_text(text_lower));
     }
 }
 
@@ -66,78 +57,81 @@ pub fn save_conversations<'a, I>(provider: ProviderKind, show_last: bool, entrie
 where
     I: IntoIterator<Item = (&'a Conversation, SourceFingerprint)>,
 {
+    let entries: Vec<_> = entries.into_iter().collect();
+    if entries.is_empty() {
+        // The common warm-start case: don't even open the database.
+        return;
+    }
+
     let Some(mut conn) = open_index_db() else {
+        let _ =
+            crate::debug_log::log_debug("conversation index: failed to open database for save");
         return;
     };
 
-    let tx = match conn.transaction() {
-        Ok(tx) => tx,
-        Err(_) => return,
-    };
+    if let Err(err) = save_conversations_to_conn(&mut conn, provider, show_last, entries) {
+        let _ = crate::debug_log::log_debug(&format!("conversation index: save failed: {err}"));
+    }
+}
+
+fn save_conversations_to_conn<'a, I>(
+    conn: &mut Connection,
+    provider: ProviderKind,
+    show_last: bool,
+    entries: I,
+) -> rusqlite::Result<()>
+where
+    I: IntoIterator<Item = (&'a Conversation, SourceFingerprint)>,
+{
+    let tx = conn.transaction()?;
 
     {
-        let mut stmt = match tx.prepare(
+        let mut stmt = tx.prepare(
             "INSERT OR REPLACE INTO file_conversations (
                 schema_version, provider, show_last, source_path, source_mtime_millis,
-                source_size, id, timestamp, preview, full_text, search_text_lower,
-                search_topic_end, project_name, project_path, cwd, message_count,
-                parse_errors_json, summary, model, total_tokens, duration_minutes
+                source_size, id, timestamp, preview, full_text, project_name,
+                project_path, cwd, message_count, parse_errors_json, summary, model,
+                total_tokens, duration_minutes
             ) VALUES (
                 ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
-                ?15, ?16, ?17, ?18, ?19, ?20, ?21
+                ?15, ?16, ?17, ?18, ?19
             )",
-        ) {
-            Ok(stmt) => stmt,
-            Err(_) => return,
-        };
+        )?;
 
         let provider_key = provider_key(&provider);
         let show_last = i64::from(show_last);
 
         for (conversation, fingerprint) in entries {
-            let Some(text_lower) = &conversation.search_text_lower else {
-                continue;
-            };
-            let topic_end = conversation
-                .search_topic_end
-                .unwrap_or_else(|| topic_end_for_text(text_lower));
             let parse_errors_json = serde_json::to_string(&conversation.parse_errors)
                 .unwrap_or_else(|_| "[]".to_string());
 
-            if stmt
-                .execute(params![
-                    SCHEMA_VERSION,
-                    provider_key,
-                    show_last,
-                    conversation.path.to_string_lossy(),
-                    fingerprint.modified_millis,
-                    fingerprint.size,
-                    conversation.id,
-                    conversation.timestamp.to_rfc3339(),
-                    conversation.preview,
-                    conversation.full_text,
-                    text_lower,
-                    topic_end as i64,
-                    conversation.project_name.as_deref(),
-                    path_to_string(conversation.project_path.as_ref()),
-                    path_to_string(conversation.cwd.as_ref()),
-                    conversation.message_count as i64,
-                    parse_errors_json,
-                    conversation.summary.as_deref(),
-                    conversation.model.as_deref(),
-                    conversation.total_tokens.min(i64::MAX as u64) as i64,
-                    conversation
-                        .duration_minutes
-                        .map(|v| v.min(i64::MAX as u64) as i64),
-                ])
-                .is_err()
-            {
-                return;
-            }
+            stmt.execute(params![
+                SCHEMA_VERSION,
+                provider_key,
+                show_last,
+                conversation.path.to_string_lossy(),
+                fingerprint.modified_millis,
+                fingerprint.size,
+                conversation.id,
+                conversation.timestamp.to_rfc3339(),
+                conversation.preview,
+                conversation.full_text,
+                conversation.project_name.as_deref(),
+                path_to_string(conversation.project_path.as_ref()),
+                path_to_string(conversation.cwd.as_ref()),
+                conversation.message_count as i64,
+                parse_errors_json,
+                conversation.summary.as_deref(),
+                conversation.model.as_deref(),
+                conversation.total_tokens.min(i64::MAX as u64) as i64,
+                conversation
+                    .duration_minutes
+                    .map(|v| v.min(i64::MAX as u64) as i64),
+            ])?;
         }
     }
 
-    let _ = tx.commit();
+    tx.commit()
 }
 
 pub fn delete_conversation(provider: ProviderKind, path: &std::path::Path) {
@@ -145,10 +139,19 @@ pub fn delete_conversation(provider: ProviderKind, path: &std::path::Path) {
         return;
     };
 
-    let _ = conn.execute(
+    let _ = delete_conversation_from_conn(&conn, provider, path);
+}
+
+fn delete_conversation_from_conn(
+    conn: &Connection,
+    provider: ProviderKind,
+    path: &std::path::Path,
+) -> rusqlite::Result<()> {
+    conn.execute(
         "DELETE FROM file_conversations WHERE provider = ?1 AND source_path = ?2",
         params![provider_key(&provider), path.to_string_lossy()],
-    );
+    )?;
+    Ok(())
 }
 
 fn load_provider_cache_from_conn(
@@ -159,9 +162,8 @@ fn load_provider_cache_from_conn(
     let mut stmt = conn.prepare(
         "SELECT
             source_path, source_mtime_millis, source_size, id, timestamp, preview,
-            full_text, search_text_lower, search_topic_end, project_name, project_path,
-            cwd, message_count, parse_errors_json, summary, model, total_tokens,
-            duration_minutes
+            full_text, project_name, project_path, cwd, message_count,
+            parse_errors_json, summary, model, total_tokens, duration_minutes
          FROM file_conversations
          WHERE schema_version = ?1 AND provider = ?2 AND show_last = ?3",
     )?;
@@ -178,12 +180,11 @@ fn load_provider_cache_from_conn(
             let timestamp = DateTime::parse_from_rfc3339(&timestamp)
                 .map(|ts| ts.with_timezone(&Local))
                 .unwrap_or_else(|_| Local::now());
-            let search_topic_end: i64 = row.get(8)?;
-            let message_count: i64 = row.get(12)?;
-            let parse_errors_json: String = row.get(13)?;
+            let message_count: i64 = row.get(10)?;
+            let parse_errors_json: String = row.get(11)?;
             let parse_errors = serde_json::from_str(&parse_errors_json).unwrap_or_default();
-            let total_tokens: i64 = row.get(16)?;
-            let duration_minutes: Option<i64> = row.get(17)?;
+            let total_tokens: i64 = row.get(14)?;
+            let duration_minutes: Option<i64> = row.get(15)?;
 
             Ok((
                 PathBuf::from(&source_path),
@@ -200,15 +201,17 @@ fn load_provider_cache_from_conn(
                         timestamp,
                         preview: row.get(5)?,
                         full_text: row.get(6)?,
-                        search_text_lower: Some(row.get(7)?),
-                        search_topic_end: Some(search_topic_end.max(0) as usize),
-                        project_name: row.get(9)?,
-                        project_path: optional_path(row.get(10)?),
-                        cwd: optional_path(row.get(11)?),
+                        // Derived in parallel by precompute_search_text at
+                        // startup; cheaper than reading them from disk.
+                        search_text_lower: None,
+                        search_topic_end: None,
+                        project_name: row.get(7)?,
+                        project_path: optional_path(row.get(8)?),
+                        cwd: optional_path(row.get(9)?),
                         message_count: message_count.max(0) as usize,
                         parse_errors,
-                        summary: row.get(14)?,
-                        model: row.get(15)?,
+                        summary: row.get(12)?,
+                        model: row.get(13)?,
                         total_tokens: total_tokens.max(0) as u64,
                         duration_minutes: duration_minutes.map(|v| v.max(0) as u64),
                     },
@@ -228,14 +231,37 @@ fn open_index_db() -> Option<Connection> {
         .join("mnemonai");
     std::fs::create_dir_all(&dir).ok()?;
     let conn = Connection::open(dir.join("conversation_index.db")).ok()?;
+    // Providers load and save in parallel threads; wait for the write lock
+    // instead of failing with SQLITE_BUSY and silently dropping the batch.
+    conn.busy_timeout(std::time::Duration::from_secs(5)).ok()?;
     init_schema(&conn).ok()?;
     Some(conn)
 }
 
-fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
-    conn.execute_batch(
-        "PRAGMA journal_mode=WAL;
-         CREATE TABLE IF NOT EXISTS file_conversations (
+/// Every column the current code reads and writes. Used to detect schema drift.
+const EXPECTED_COLUMNS: [&str; 19] = [
+    "schema_version",
+    "provider",
+    "show_last",
+    "source_path",
+    "source_mtime_millis",
+    "source_size",
+    "id",
+    "timestamp",
+    "preview",
+    "full_text",
+    "project_name",
+    "project_path",
+    "cwd",
+    "message_count",
+    "parse_errors_json",
+    "summary",
+    "model",
+    "total_tokens",
+    "duration_minutes",
+];
+
+const CREATE_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS file_conversations (
              schema_version        INTEGER NOT NULL,
              provider              TEXT NOT NULL,
              show_last             INTEGER NOT NULL,
@@ -246,8 +272,6 @@ fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
              timestamp             TEXT NOT NULL,
              preview               TEXT NOT NULL,
              full_text             TEXT NOT NULL,
-             search_text_lower     TEXT NOT NULL,
-             search_topic_end      INTEGER NOT NULL,
              project_name          TEXT,
              project_path          TEXT,
              cwd                   TEXT,
@@ -258,8 +282,42 @@ fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
              total_tokens          INTEGER NOT NULL,
              duration_minutes      INTEGER,
              PRIMARY KEY (schema_version, provider, show_last, source_path)
-         );",
-    )
+         );";
+
+fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
+    // synchronous=NORMAL is safe with WAL (no corruption on crash) and makes
+    // the large cold-start commit considerably cheaper than FULL.
+    conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")?;
+    // CREATE TABLE IF NOT EXISTS silently keeps whatever shape an older build
+    // created, after which every INSERT and SELECT here fails with "no such
+    // column" — and the cache never reads or writes again. Validate the column
+    // set and rebuild on drift; this is a cache, so the only cost is one
+    // re-parse of changed providers.
+    if !table_matches_expected_columns(conn)? {
+        conn.execute_batch("DROP TABLE IF EXISTS file_conversations;")?;
+        // Return the dropped table's pages to the filesystem; without this a
+        // previously bloated database file keeps its size forever.
+        conn.execute_batch("VACUUM;")?;
+        conn.execute_batch(CREATE_TABLE_SQL)?;
+    }
+    Ok(())
+}
+
+fn table_matches_expected_columns(conn: &Connection) -> rusqlite::Result<bool> {
+    let mut stmt = conn.prepare("SELECT name FROM pragma_table_info('file_conversations')")?;
+    let mut existing = stmt
+        .query_map([], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<String>>>()?;
+    existing.sort_unstable();
+
+    let mut expected = EXPECTED_COLUMNS;
+    expected.sort_unstable();
+
+    Ok(existing.len() == expected.len()
+        && existing
+            .iter()
+            .map(String::as_str)
+            .eq(expected.iter().copied()))
 }
 
 fn provider_key(provider: &ProviderKind) -> &'static str {
@@ -314,24 +372,8 @@ mod tests {
     }
 
     #[test]
-    fn attach_search_cache_populates_lowercase_text() {
-        let mut conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
-
-        attach_search_cache(&mut conversation);
-
-        assert_eq!(
-            conversation.search_text_lower.as_deref(),
-            Some("hello cache body")
-        );
-        assert_eq!(
-            conversation.search_topic_end,
-            Some("hello cache body".len())
-        );
-    }
-
-    #[test]
     fn load_cache_round_trips_conversation() {
-        let conn = Connection::open_in_memory().unwrap();
+        let mut conn = Connection::open_in_memory().unwrap();
         init_schema(&conn).unwrap();
         let mut conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
         conversation.parse_errors.push(crate::history::ParseError {
@@ -341,14 +383,67 @@ mod tests {
             context_before: vec!["before".to_string()],
             context_after: vec!["after".to_string()],
         });
-        attach_search_cache(&mut conversation);
         let fingerprint = SourceFingerprint {
             modified_millis: 123,
             size: 456,
         };
 
         save_conversations_to_conn(
-            &conn,
+            &mut conn,
+            ProviderKind::Claude,
+            false,
+            [(&conversation, fingerprint)],
+        )
+        .unwrap();
+
+        let mut cache = load_provider_cache_from_conn(&conn, ProviderKind::Claude, false).unwrap();
+        let cached = cache.remove(&conversation.path).unwrap();
+
+        assert!(
+            cached
+                .clone()
+                .into_conversation_if_fresh(SourceFingerprint {
+                    modified_millis: 999,
+                    size: 456
+                })
+                .is_none()
+        );
+
+        let loaded = cached.into_conversation_if_fresh(fingerprint).unwrap();
+        assert_eq!(loaded.id, "session-1");
+        assert_eq!(loaded.parse_errors.len(), 1);
+        assert_eq!(loaded.parse_errors[0].line_number, 7);
+        assert_eq!(loaded.full_text, "Hello Cache Body");
+        // Search text is recomputed at startup rather than persisted.
+        assert!(loaded.search_text_lower.is_none());
+    }
+
+    #[test]
+    fn init_schema_rebuilds_drifted_table() {
+        // Simulate a table created by an older build: same name, missing the
+        // full_text/search_text_lower columns the current code requires.
+        let mut conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE file_conversations (
+                schema_version INTEGER NOT NULL,
+                provider       TEXT NOT NULL,
+                source_path    TEXT NOT NULL,
+                preview        TEXT NOT NULL,
+                PRIMARY KEY (schema_version, provider, source_path)
+            );",
+        )
+        .unwrap();
+
+        init_schema(&conn).unwrap();
+
+        // Save + load must round-trip after the rebuild.
+        let mut conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
+        let fingerprint = SourceFingerprint {
+            modified_millis: 1,
+            size: 2,
+        };
+        save_conversations_to_conn(
+            &mut conn,
             ProviderKind::Claude,
             false,
             [(&conversation, fingerprint)],
@@ -356,24 +451,31 @@ mod tests {
         .unwrap();
 
         let cache = load_provider_cache_from_conn(&conn, ProviderKind::Claude, false).unwrap();
-        let cached = cache.get(&conversation.path).unwrap();
-        let loaded = cached.conversation_if_fresh(fingerprint).unwrap();
+        assert!(cache.contains_key(&conversation.path));
+    }
 
-        assert_eq!(loaded.id, "session-1");
-        assert_eq!(loaded.parse_errors.len(), 1);
-        assert_eq!(loaded.parse_errors[0].line_number, 7);
-        assert_eq!(
-            loaded.search_text_lower.as_deref(),
-            Some("hello cache body")
-        );
-        assert!(
-            cached
-                .conversation_if_fresh(SourceFingerprint {
-                    modified_millis: 999,
-                    size: 456
-                })
-                .is_none()
-        );
+    #[test]
+    fn init_schema_preserves_rows_when_schema_matches() {
+        let mut conn = Connection::open_in_memory().unwrap();
+        init_schema(&conn).unwrap();
+        let mut conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
+        let fingerprint = SourceFingerprint {
+            modified_millis: 1,
+            size: 2,
+        };
+        save_conversations_to_conn(
+            &mut conn,
+            ProviderKind::Claude,
+            false,
+            [(&conversation, fingerprint)],
+        )
+        .unwrap();
+
+        // Re-running init_schema (a second app start) must not wipe the cache.
+        init_schema(&conn).unwrap();
+
+        let cache = load_provider_cache_from_conn(&conn, ProviderKind::Claude, false).unwrap();
+        assert!(cache.contains_key(&conversation.path));
     }
 
     #[test]
@@ -381,28 +483,27 @@ mod tests {
         let mut conn = Connection::open_in_memory().unwrap();
         init_schema(&conn).unwrap();
         let mut conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
-        attach_search_cache(&mut conversation);
         let fingerprint = SourceFingerprint {
             modified_millis: 123,
             size: 456,
         };
 
         save_conversations_to_conn(
-            &conn,
+            &mut conn,
             ProviderKind::Claude,
             false,
             [(&conversation, fingerprint)],
         )
         .unwrap();
         save_conversations_to_conn(
-            &conn,
+            &mut conn,
             ProviderKind::Claude,
             true,
             [(&conversation, fingerprint)],
         )
         .unwrap();
 
-        delete_conversation_from_conn(&mut conn, ProviderKind::Claude, &conversation.path).unwrap();
+        delete_conversation_from_conn(&conn, ProviderKind::Claude, &conversation.path).unwrap();
 
         assert!(
             load_provider_cache_from_conn(&conn, ProviderKind::Claude, false)
@@ -414,68 +515,5 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
-    }
-
-    fn save_conversations_to_conn<'a, I>(
-        conn: &Connection,
-        provider: ProviderKind,
-        show_last: bool,
-        entries: I,
-    ) -> rusqlite::Result<()>
-    where
-        I: IntoIterator<Item = (&'a Conversation, SourceFingerprint)>,
-    {
-        let mut stmt = conn.prepare(
-            "INSERT OR REPLACE INTO file_conversations (
-                schema_version, provider, show_last, source_path, source_mtime_millis,
-                source_size, id, timestamp, preview, full_text, search_text_lower,
-                search_topic_end, project_name, project_path, cwd, message_count,
-                parse_errors_json, summary, model, total_tokens, duration_minutes
-            ) VALUES (
-                ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
-                ?15, ?16, ?17, ?18, ?19, ?20, ?21
-            )",
-        )?;
-
-        for (conversation, fingerprint) in entries {
-            let parse_errors_json = serde_json::to_string(&conversation.parse_errors).unwrap();
-            stmt.execute(params![
-                SCHEMA_VERSION,
-                provider_key(&provider),
-                i64::from(show_last),
-                conversation.path.to_string_lossy(),
-                fingerprint.modified_millis,
-                fingerprint.size,
-                conversation.id,
-                conversation.timestamp.to_rfc3339(),
-                conversation.preview,
-                conversation.full_text,
-                conversation.search_text_lower.as_deref().unwrap(),
-                conversation.search_topic_end.unwrap() as i64,
-                conversation.project_name.as_deref(),
-                path_to_string(conversation.project_path.as_ref()),
-                path_to_string(conversation.cwd.as_ref()),
-                conversation.message_count as i64,
-                parse_errors_json,
-                conversation.summary.as_deref(),
-                conversation.model.as_deref(),
-                conversation.total_tokens as i64,
-                conversation.duration_minutes.map(|v| v as i64),
-            ])?;
-        }
-
-        Ok(())
-    }
-
-    fn delete_conversation_from_conn(
-        conn: &mut Connection,
-        provider: ProviderKind,
-        path: &std::path::Path,
-    ) -> rusqlite::Result<()> {
-        conn.execute(
-            "DELETE FROM file_conversations WHERE provider = ?1 AND source_path = ?2",
-            params![provider_key(&provider), path.to_string_lossy()],
-        )?;
-        Ok(())
     }
 }

--- a/src/conversation_index.rs
+++ b/src/conversation_index.rs
@@ -5,7 +5,7 @@
 
 use crate::history::{Conversation, ProviderKind};
 use chrono::{DateTime, Local};
-use rusqlite::{Connection, params};
+use rusqlite::{Connection, TransactionBehavior, params};
 use std::collections::HashMap;
 use std::fs::Metadata;
 use std::path::PathBuf;
@@ -258,11 +258,11 @@ fn open_index_db() -> Option<Connection> {
         .join("state")
         .join("mnemonai");
     std::fs::create_dir_all(&dir).ok()?;
-    let conn = Connection::open(dir.join("conversation_index.db")).ok()?;
+    let mut conn = Connection::open(dir.join("conversation_index.db")).ok()?;
     // Providers load and save in parallel threads; wait for the write lock
     // instead of failing with SQLITE_BUSY and silently dropping the batch.
     conn.busy_timeout(std::time::Duration::from_secs(5)).ok()?;
-    init_schema(&conn).ok()?;
+    init_schema(&mut conn).ok()?;
     Some(conn)
 }
 
@@ -312,7 +312,7 @@ const CREATE_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS file_conversations (
              PRIMARY KEY (schema_version, provider, show_last, source_path)
          );";
 
-fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
+fn init_schema(conn: &mut Connection) -> rusqlite::Result<()> {
     // synchronous=NORMAL is safe with WAL (no corruption on crash) and makes
     // the large cold-start commit considerably cheaper than FULL.
     conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA synchronous=NORMAL;")?;
@@ -321,12 +321,28 @@ fn init_schema(conn: &Connection) -> rusqlite::Result<()> {
     // column" — and the cache never reads or writes again. Validate the column
     // set and rebuild on drift; this is a cache, so the only cost is one
     // re-parse of changed providers.
-    if !table_matches_expected_columns(conn)? {
-        conn.execute_batch("DROP TABLE IF EXISTS file_conversations;")?;
+    if table_matches_expected_columns(conn)? {
+        return Ok(());
+    }
+
+    // Re-check under the write lock: providers open this database concurrently
+    // at startup, and the check-then-rebuild must be atomic so a stale check
+    // can never drop a table another connection just rebuilt (and possibly
+    // populated). Exactly one connection rebuilds; the rest see the fresh
+    // table here and leave it alone.
+    let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+    let drifted = !table_matches_expected_columns(&tx)?;
+    if drifted {
+        tx.execute_batch("DROP TABLE IF EXISTS file_conversations;")?;
+        tx.execute_batch(CREATE_TABLE_SQL)?;
+    }
+    tx.commit()?;
+
+    if drifted {
         // Return the dropped table's pages to the filesystem; without this a
-        // previously bloated database file keeps its size forever.
-        conn.execute_batch("VACUUM;")?;
-        conn.execute_batch(CREATE_TABLE_SQL)?;
+        // previously bloated database file keeps its size forever. Best-effort:
+        // VACUUM cannot run inside the transaction above.
+        let _ = conn.execute_batch("VACUUM;");
     }
     Ok(())
 }
@@ -402,7 +418,7 @@ mod tests {
     #[test]
     fn load_cache_round_trips_conversation() {
         let mut conn = Connection::open_in_memory().unwrap();
-        init_schema(&conn).unwrap();
+        init_schema(&mut conn).unwrap();
         let mut conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
         conversation.parse_errors.push(crate::history::ParseError {
             line_number: 7,
@@ -462,7 +478,7 @@ mod tests {
         )
         .unwrap();
 
-        init_schema(&conn).unwrap();
+        init_schema(&mut conn).unwrap();
 
         // Save + load must round-trip after the rebuild.
         let conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
@@ -485,7 +501,7 @@ mod tests {
     #[test]
     fn init_schema_preserves_rows_when_schema_matches() {
         let mut conn = Connection::open_in_memory().unwrap();
-        init_schema(&conn).unwrap();
+        init_schema(&mut conn).unwrap();
         let conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
         let fingerprint = SourceFingerprint {
             modified_millis: 1,
@@ -500,7 +516,7 @@ mod tests {
         .unwrap();
 
         // Re-running init_schema (a second app start) must not wipe the cache.
-        init_schema(&conn).unwrap();
+        init_schema(&mut conn).unwrap();
 
         let cache = load_provider_cache_from_conn(&conn, ProviderKind::Claude, false).unwrap();
         assert!(cache.contains_key(&conversation.path));
@@ -509,7 +525,7 @@ mod tests {
     #[test]
     fn delete_conversation_removes_cached_rows_for_all_preview_modes() {
         let mut conn = Connection::open_in_memory().unwrap();
-        init_schema(&conn).unwrap();
+        init_schema(&mut conn).unwrap();
         let conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
         let fingerprint = SourceFingerprint {
             modified_millis: 123,

--- a/src/conversation_index.rs
+++ b/src/conversation_index.rs
@@ -28,8 +28,11 @@ pub struct CachedFileConversation {
 impl CachedFileConversation {
     /// Consume the cache entry, returning the conversation when the source file
     /// is unchanged. Moving (rather than cloning) matters: cached entries carry
-    /// the full conversation text twice (original + lowercased).
-    pub fn into_conversation_if_fresh(self, fingerprint: SourceFingerprint) -> Option<Conversation> {
+    /// the conversation's full text.
+    pub fn into_conversation_if_fresh(
+        self,
+        fingerprint: SourceFingerprint,
+    ) -> Option<Conversation> {
         let fresh = self.fingerprint == fingerprint;
         fresh.then_some(self.conversation)
     }
@@ -64,8 +67,7 @@ where
     }
 
     let Some(mut conn) = open_index_db() else {
-        let _ =
-            crate::debug_log::log_debug("conversation index: failed to open database for save");
+        let _ = crate::debug_log::log_debug("conversation index: failed to open database for save");
         return;
     };
 
@@ -140,6 +142,32 @@ pub fn delete_conversation(provider: ProviderKind, path: &std::path::Path) {
     };
 
     let _ = delete_conversation_from_conn(&conn, provider, path);
+}
+
+/// Remove cached rows for source files that no longer exist. Callers pass the
+/// paths left over in the cache map after a full provider scan consumed every
+/// current file — anything still in the map has disappeared from disk (or been
+/// excluded), and keeping it would grow the database and slow every load.
+/// Only call this after a complete scan, never for a single-project load.
+pub fn prune_conversations(provider: ProviderKind, paths: &[PathBuf]) {
+    if paths.is_empty() {
+        return;
+    }
+
+    let Some(mut conn) = open_index_db() else {
+        return;
+    };
+
+    let Ok(tx) = conn.transaction() else {
+        return;
+    };
+    for path in paths {
+        let _ = tx.execute(
+            "DELETE FROM file_conversations WHERE provider = ?1 AND source_path = ?2",
+            params![provider_key(&provider), path.to_string_lossy()],
+        );
+    }
+    let _ = tx.commit();
 }
 
 fn delete_conversation_from_conn(
@@ -437,7 +465,7 @@ mod tests {
         init_schema(&conn).unwrap();
 
         // Save + load must round-trip after the rebuild.
-        let mut conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
+        let conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
         let fingerprint = SourceFingerprint {
             modified_millis: 1,
             size: 2,
@@ -458,7 +486,7 @@ mod tests {
     fn init_schema_preserves_rows_when_schema_matches() {
         let mut conn = Connection::open_in_memory().unwrap();
         init_schema(&conn).unwrap();
-        let mut conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
+        let conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
         let fingerprint = SourceFingerprint {
             modified_millis: 1,
             size: 2,
@@ -482,7 +510,7 @@ mod tests {
     fn delete_conversation_removes_cached_rows_for_all_preview_modes() {
         let mut conn = Connection::open_in_memory().unwrap();
         init_schema(&conn).unwrap();
-        let mut conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
+        let conversation = make_conversation(PathBuf::from("/tmp/session.jsonl"));
         let fingerprint = SourceFingerprint {
             modified_millis: 123,
             size: 456,

--- a/src/display.rs
+++ b/src/display.rs
@@ -533,7 +533,8 @@ fn process_entry<F: OutputFormatter>(
     match entry {
         LogEntry::Summary { .. }
         | LogEntry::FileHistorySnapshot { .. }
-        | LogEntry::System { .. } => {
+        | LogEntry::System { .. }
+        | LogEntry::Unknown => {
             // Skip metadata entries
         }
         LogEntry::Progress { data, .. } => {

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -55,6 +55,7 @@ pub fn load_all_conversations(
 
     let cache = Mutex::new(load_provider_cache(ProviderKind::Claude, show_last));
     let fresh_acc: Mutex<Vec<(Conversation, SourceFingerprint)>> = Mutex::new(Vec::new());
+    let failed_projects: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
 
     // Load conversations from all projects in parallel
     let mut all_conversations: Vec<Conversation> = projects
@@ -85,6 +86,7 @@ pub fn load_all_conversations(
                         debug_level,
                         &format!("Failed to load project {}: {}", project.display_name, e),
                     );
+                    failed_projects.lock().unwrap().push(project_dir);
                     Vec::new()
                 }
             }
@@ -100,10 +102,17 @@ pub fn load_all_conversations(
         fresh.iter().map(|(conv, fingerprint)| (conv, *fingerprint)),
     );
 
-    // Entries no project claimed belong to files that no longer exist.
+    // Entries no project claimed belong to files that no longer exist — except
+    // under a project that failed to load, where we simply don't know.
+    let failed = failed_projects.into_inner().unwrap_or_default();
     let stale: Vec<PathBuf> = cache
         .into_inner()
-        .map(|cache| cache.into_keys().collect())
+        .map(|cache| {
+            cache
+                .into_keys()
+                .filter(|path| !failed.iter().any(|dir| path.starts_with(dir)))
+                .collect()
+        })
         .unwrap_or_default();
     prune_conversations(ProviderKind::Claude, &stale);
 
@@ -180,6 +189,7 @@ fn load_all_streaming_inner(
 
     let cache = Mutex::new(load_provider_cache(ProviderKind::Claude, show_last));
     let fresh_acc: Mutex<Vec<(Conversation, SourceFingerprint)>> = Mutex::new(Vec::new());
+    let failed_projects: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
 
     // Process projects in parallel and send batches as they complete
     projects.par_iter().for_each(|project| {
@@ -210,6 +220,7 @@ fn load_all_streaming_inner(
                     debug_level,
                     &format!("Failed to load project {}: {}", project.display_name, e),
                 );
+                failed_projects.lock().unwrap().push(project_dir);
                 let _ = tx.send(LoaderMessage::ProjectError);
             }
         }
@@ -224,10 +235,17 @@ fn load_all_streaming_inner(
         fresh.iter().map(|(conv, fingerprint)| (conv, *fingerprint)),
     );
 
-    // Entries no project claimed belong to files that no longer exist.
+    // Entries no project claimed belong to files that no longer exist — except
+    // under a project that failed to load, where we simply don't know.
+    let failed = failed_projects.into_inner().unwrap_or_default();
     let stale: Vec<PathBuf> = cache
         .into_inner()
-        .map(|cache| cache.into_keys().collect())
+        .map(|cache| {
+            cache
+                .into_keys()
+                .filter(|path| !failed.iter().any(|dir| path.starts_with(dir)))
+                .collect()
+        })
         .unwrap_or_default();
     prune_conversations(ProviderKind::Claude, &stale);
 
@@ -376,12 +394,12 @@ fn load_conversations_with_cache(
                 .unwrap_or("unknown")
                 .to_owned();
 
-            if let Some(fingerprint) = fingerprint
-                && let Some(conversation) = cache
-                    .lock()
-                    .ok()
-                    .and_then(|mut cache| cache.remove(&path))
-                    .and_then(|cached| cached.into_conversation_if_fresh(fingerprint))
+            // Always consume the cache entry for a file we've seen: whatever
+            // remains in the map afterwards is treated as deleted and pruned,
+            // and a file that merely failed to stat or parse isn't deleted.
+            let cached_entry = cache.lock().ok().and_then(|mut cache| cache.remove(&path));
+            if let (Some(fingerprint), Some(cached)) = (fingerprint, cached_entry)
+                && let Some(conversation) = cached.into_conversation_if_fresh(fingerprint)
             {
                 debug::debug(
                     debug_level,

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -11,7 +11,7 @@ use super::{Conversation, LoaderMessage, Project};
 use crate::cli::DebugLevel;
 use crate::conversation_index::{
     CachedFileConversation, SourceFingerprint, fingerprint_from_metadata, load_provider_cache,
-    save_conversations,
+    prune_conversations, save_conversations,
 };
 use crate::debug;
 use crate::error::{AppError, Result};
@@ -99,6 +99,13 @@ pub fn load_all_conversations(
         show_last,
         fresh.iter().map(|(conv, fingerprint)| (conv, *fingerprint)),
     );
+
+    // Entries no project claimed belong to files that no longer exist.
+    let stale: Vec<PathBuf> = cache
+        .into_inner()
+        .map(|cache| cache.into_keys().collect())
+        .unwrap_or_default();
+    prune_conversations(ProviderKind::Claude, &stale);
 
     // Global sort by timestamp (newest first)
     all_conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
@@ -216,6 +223,13 @@ fn load_all_streaming_inner(
         show_last,
         fresh.iter().map(|(conv, fingerprint)| (conv, *fingerprint)),
     );
+
+    // Entries no project claimed belong to files that no longer exist.
+    let stale: Vec<PathBuf> = cache
+        .into_inner()
+        .map(|cache| cache.into_keys().collect())
+        .unwrap_or_default();
+    prune_conversations(ProviderKind::Claude, &stale);
 
     let _ = tx.send(LoaderMessage::Done);
 }

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -10,8 +10,8 @@ use super::path::{
 use super::{Conversation, LoaderMessage, Project};
 use crate::cli::DebugLevel;
 use crate::conversation_index::{
-    CachedFileConversation, SourceFingerprint, attach_search_cache, fingerprint_from_metadata,
-    load_provider_cache, save_conversations,
+    CachedFileConversation, SourceFingerprint, fingerprint_from_metadata, load_provider_cache,
+    save_conversations,
 };
 use crate::debug;
 use crate::error::{AppError, Result};
@@ -20,6 +20,7 @@ use rayon::prelude::*;
 use std::collections::HashMap;
 use std::fs::read_dir;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread;
 use std::time::SystemTime;
@@ -52,7 +53,8 @@ pub fn load_all_conversations(
         &format!("Loading global history from {} projects", projects.len()),
     );
 
-    let cache = load_provider_cache(ProviderKind::Claude, show_last);
+    let cache = Mutex::new(load_provider_cache(ProviderKind::Claude, show_last));
+    let fresh_acc: Mutex<Vec<(Conversation, SourceFingerprint)>> = Mutex::new(Vec::new());
 
     // Load conversations from all projects in parallel
     let mut all_conversations: Vec<Conversation> = projects
@@ -60,7 +62,11 @@ pub fn load_all_conversations(
         .flat_map(|project| {
             let project_dir = root.join(&project.name);
             match load_conversations_with_cache(&project_dir, show_last, debug_level, &cache) {
-                Ok(mut convs) => {
+                Ok((mut convs, fresh)) => {
+                    if !fresh.is_empty() {
+                        fresh_acc.lock().unwrap().extend(fresh);
+                    }
+
                     // Fallback path for old JSONL files without cwd field
                     let fallback_path = decode_project_dir_name_to_path(&project.name);
 
@@ -84,6 +90,15 @@ pub fn load_all_conversations(
             }
         })
         .collect();
+
+    // One write transaction for the whole run, instead of one per project
+    // racing each other for the SQLite write lock.
+    let fresh = fresh_acc.into_inner().unwrap_or_default();
+    save_conversations(
+        ProviderKind::Claude,
+        show_last,
+        fresh.iter().map(|(conv, fingerprint)| (conv, *fingerprint)),
+    );
 
     // Global sort by timestamp (newest first)
     all_conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
@@ -156,14 +171,18 @@ fn load_all_streaming_inner(
         &format!("Loading global history from {} projects", projects.len()),
     );
 
-    let cache = load_provider_cache(ProviderKind::Claude, show_last);
+    let cache = Mutex::new(load_provider_cache(ProviderKind::Claude, show_last));
+    let fresh_acc: Mutex<Vec<(Conversation, SourceFingerprint)>> = Mutex::new(Vec::new());
 
     // Process projects in parallel and send batches as they complete
     projects.par_iter().for_each(|project| {
         let project_dir = root.join(&project.name);
 
         match load_conversations_with_cache(&project_dir, show_last, debug_level, &cache) {
-            Ok(mut convs) => {
+            Ok((mut convs, fresh)) => {
+                if !fresh.is_empty() {
+                    fresh_acc.lock().unwrap().extend(fresh);
+                }
                 if convs.is_empty() {
                     return;
                 }
@@ -188,6 +207,15 @@ fn load_all_streaming_inner(
             }
         }
     });
+
+    // All batches are on the channel; persist newly parsed conversations in a
+    // single write transaction so the next start can skip re-parsing them.
+    let fresh = fresh_acc.into_inner().unwrap_or_default();
+    save_conversations(
+        ProviderKind::Claude,
+        show_last,
+        fresh.iter().map(|(conv, fingerprint)| (conv, *fingerprint)),
+    );
 
     let _ = tx.send(LoaderMessage::Done);
 }
@@ -264,16 +292,26 @@ pub fn load_conversations(
     show_last: bool,
     debug_level: Option<DebugLevel>,
 ) -> Result<Vec<Conversation>> {
-    let cache = load_provider_cache(ProviderKind::Claude, show_last);
-    load_conversations_with_cache(projects_dir, show_last, debug_level, &cache)
+    let cache = Mutex::new(load_provider_cache(ProviderKind::Claude, show_last));
+    let (conversations, fresh) =
+        load_conversations_with_cache(projects_dir, show_last, debug_level, &cache)?;
+    save_conversations(
+        ProviderKind::Claude,
+        show_last,
+        fresh.iter().map(|(conv, fingerprint)| (conv, *fingerprint)),
+    );
+    Ok(conversations)
 }
 
+/// Load one project directory. Returns the conversations plus clones of the
+/// freshly parsed ones (cache misses) so the caller can persist them in a
+/// single batch — per-project writes would race for the SQLite write lock.
 fn load_conversations_with_cache(
     projects_dir: &Path,
     show_last: bool,
     debug_level: Option<DebugLevel>,
-    cache: &HashMap<PathBuf, CachedFileConversation>,
-) -> Result<Vec<Conversation>> {
+    cache: &Mutex<HashMap<PathBuf, CachedFileConversation>>,
+) -> Result<(Vec<Conversation>, Vec<(Conversation, SourceFingerprint)>)> {
     // Find all JSONL files and capture metadata in one pass
     let mut files_with_meta = Vec::new();
     let mut skipped_agent_files = 0;
@@ -326,8 +364,10 @@ fn load_conversations_with_cache(
 
             if let Some(fingerprint) = fingerprint
                 && let Some(conversation) = cache
-                    .get(&path)
-                    .and_then(|cached| cached.conversation_if_fresh(fingerprint))
+                    .lock()
+                    .ok()
+                    .and_then(|mut cache| cache.remove(&path))
+                    .and_then(|cached| cached.into_conversation_if_fresh(fingerprint))
             {
                 debug::debug(
                     debug_level,
@@ -337,12 +377,11 @@ fn load_conversations_with_cache(
             }
 
             match process_conversation_file(path, show_last, modified, debug_level) {
-                Ok(Some(mut conversation)) => {
+                Ok(Some(conversation)) => {
                     debug::debug(
                         debug_level,
                         &format!("Loaded {}: {}", filename, conversation.preview),
                     );
-                    attach_search_cache(&mut conversation);
                     match fingerprint {
                         Some(fingerprint) => {
                             Some(ConversationLoad::Fresh(conversation, fingerprint))
@@ -362,16 +401,18 @@ fn load_conversations_with_cache(
         })
         .collect();
 
-    save_conversations(
-        ProviderKind::Claude,
-        show_last,
-        loaded.iter().filter_map(|loaded| match loaded {
+    // Clone the freshly parsed conversations for the caller to persist later.
+    // On warm starts nearly everything is cached, so this clones little or
+    // nothing; only a cold start pays for the copies.
+    let fresh: Vec<(Conversation, SourceFingerprint)> = loaded
+        .iter()
+        .filter_map(|loaded| match loaded {
             ConversationLoad::Fresh(conversation, fingerprint) => {
-                Some((conversation, *fingerprint))
+                Some((conversation.clone(), *fingerprint))
             }
             ConversationLoad::Cached(_) => None,
-        }),
-    );
+        })
+        .collect();
 
     let mut conversations: Vec<Conversation> = loaded
         .into_iter()
@@ -401,5 +442,5 @@ fn load_conversations_with_cache(
         &format!("Total conversations loaded: {}", conversations.len()),
     );
 
-    Ok(conversations)
+    Ok((conversations, fresh))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,11 @@ fn run() -> Result<()> {
         Box::new(providers::cursor::CursorProvider::new()),
     ];
 
+    // Handle --bench-startup flag: time the streaming load headlessly and exit
+    if args.bench_startup {
+        return bench_startup(&providers, show_last, args.debug);
+    }
+
     // Handle --render flag: render a JSONL file in ledger format and exit
     if let Some(ref render_path) = args.render {
         let display_options = display::DisplayOptions {
@@ -304,6 +309,92 @@ fn run() -> Result<()> {
     } else {
         display::display_conversation(&selected_path, &display_options)?;
     }
+
+    Ok(())
+}
+
+/// Drain every provider's streaming loader without the TUI and print timing
+/// information. Used to measure startup loading performance (--bench-startup).
+fn bench_startup(
+    providers: &[Box<dyn Provider>],
+    show_last: bool,
+    debug_level: Option<cli::DebugLevel>,
+) -> Result<()> {
+    use std::time::Instant;
+
+    let overall = Instant::now();
+
+    // Start all providers first (mirrors real startup), then drain each in its
+    // own thread so a slow provider doesn't block the others' message streams.
+    let receivers: Vec<(String, Receiver<LoaderMessage>)> = providers
+        .iter()
+        .map(|p| {
+            (
+                p.name().to_string(),
+                p.load_conversations_streaming(show_last, debug_level),
+            )
+        })
+        .collect();
+
+    let handles: Vec<_> = receivers
+        .into_iter()
+        .map(|(name, rx)| {
+            std::thread::spawn(move || {
+                let mut first_batch_ms: Option<u128> = None;
+                let mut conversations = 0usize;
+                let mut batches = 0usize;
+                let mut errors = 0usize;
+                for msg in rx {
+                    match msg {
+                        LoaderMessage::Batch(batch) => {
+                            batches += 1;
+                            conversations += batch.len();
+                            first_batch_ms.get_or_insert_with(|| overall.elapsed().as_millis());
+                        }
+                        LoaderMessage::ProjectError => errors += 1,
+                        LoaderMessage::Fatal(_) => {
+                            errors += 1;
+                            break;
+                        }
+                        LoaderMessage::Done => break,
+                    }
+                }
+                let done_ms = overall.elapsed().as_millis();
+                (name, first_batch_ms, done_ms, conversations, batches, errors)
+            })
+        })
+        .collect();
+
+    let mut results: Vec<_> = handles
+        .into_iter()
+        .filter_map(|h| h.join().ok())
+        .collect();
+    results.sort_by_key(|r| r.2);
+
+    let total_ms = overall.elapsed().as_millis();
+    let total_convs: usize = results.iter().map(|r| r.3).sum();
+
+    println!(
+        "{:<18} {:>12} {:>10} {:>8} {:>8} {:>7}",
+        "provider", "first batch", "done", "convs", "batches", "errors"
+    );
+    for (name, first_batch_ms, done_ms, convs, batches, errors) in &results {
+        println!(
+            "{:<18} {:>12} {:>10} {:>8} {:>8} {:>7}",
+            name,
+            first_batch_ms
+                .map(|ms| format!("{} ms", ms))
+                .unwrap_or_else(|| "-".to_string()),
+            format!("{} ms", done_ms),
+            convs,
+            batches,
+            errors
+        );
+    }
+    println!(
+        "\ntotal: {} conversations in {} ms (all providers done)",
+        total_convs, total_ms
+    );
 
     Ok(())
 }

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -1,8 +1,8 @@
 use crate::claude::{AssistantMessage, ContentBlock, LogEntry, UserContent, UserMessage};
 use crate::cli::DebugLevel;
 use crate::conversation_index::{
-    SourceFingerprint, attach_search_cache, delete_conversation, fingerprint_from_metadata,
-    load_provider_cache, save_conversations,
+    SourceFingerprint, delete_conversation, fingerprint_from_metadata, load_provider_cache,
+    save_conversations,
 };
 use crate::debug;
 use crate::error::{AppError, Result};
@@ -17,6 +17,7 @@ use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Mutex;
 use std::sync::mpsc::{self, Receiver};
 use std::time::SystemTime;
 
@@ -85,7 +86,7 @@ impl CodexProvider {
         }
 
         let files = collect_session_files(&root);
-        let cache = load_provider_cache(ProviderKind::Codex, show_last);
+        let cache = Mutex::new(load_provider_cache(ProviderKind::Codex, show_last));
         let loaded: Vec<ConversationLoad> = files
             .into_par_iter()
             .filter_map(|path| {
@@ -102,8 +103,10 @@ impl CodexProvider {
 
                 if let Some(fingerprint) = fingerprint
                     && let Some(conversation) = cache
-                        .get(&path)
-                        .and_then(|cached| cached.conversation_if_fresh(fingerprint))
+                        .lock()
+                        .ok()
+                        .and_then(|mut cache| cache.remove(&path))
+                        .and_then(|cached| cached.into_conversation_if_fresh(fingerprint))
                 {
                     debug::debug(
                         debug_level,
@@ -113,7 +116,7 @@ impl CodexProvider {
                 }
 
                 match process_codex_transcript_file(path, show_last, modified, debug_level) {
-                    Ok(Some(mut conversation)) => {
+                    Ok(Some(conversation)) => {
                         debug::debug(
                             debug_level,
                             &format!(
@@ -121,7 +124,6 @@ impl CodexProvider {
                                 filename, conversation.preview
                             ),
                         );
-                        attach_search_cache(&mut conversation);
                         match fingerprint {
                             Some(fingerprint) => {
                                 Some(ConversationLoad::Fresh(conversation, fingerprint))

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -2,7 +2,7 @@ use crate::claude::{AssistantMessage, ContentBlock, LogEntry, UserContent, UserM
 use crate::cli::DebugLevel;
 use crate::conversation_index::{
     SourceFingerprint, delete_conversation, fingerprint_from_metadata, load_provider_cache,
-    save_conversations,
+    prune_conversations, save_conversations,
 };
 use crate::debug;
 use crate::error::{AppError, Result};
@@ -153,6 +153,13 @@ impl CodexProvider {
                 ConversationLoad::Cached(_) => None,
             }),
         );
+
+        // Entries no session file claimed belong to files that no longer exist.
+        let stale: Vec<PathBuf> = cache
+            .into_inner()
+            .map(|cache| cache.into_keys().collect())
+            .unwrap_or_default();
+        prune_conversations(ProviderKind::Codex, &stale);
 
         let mut conversations: Vec<Conversation> = loaded
             .into_iter()

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -101,12 +101,12 @@ impl CodexProvider {
                     .and_then(|metadata| metadata.modified().ok());
                 let fingerprint = metadata.as_ref().map(fingerprint_from_metadata);
 
-                if let Some(fingerprint) = fingerprint
-                    && let Some(conversation) = cache
-                        .lock()
-                        .ok()
-                        .and_then(|mut cache| cache.remove(&path))
-                        .and_then(|cached| cached.into_conversation_if_fresh(fingerprint))
+                // Always consume the cache entry for a file we've seen: whatever
+                // remains in the map afterwards is treated as deleted and pruned,
+                // and a file that merely failed to stat or parse isn't deleted.
+                let cached_entry = cache.lock().ok().and_then(|mut cache| cache.remove(&path));
+                if let (Some(fingerprint), Some(cached)) = (fingerprint, cached_entry)
+                    && let Some(conversation) = cached.into_conversation_if_fresh(fingerprint)
                 {
                     debug::debug(
                         debug_level,

--- a/src/providers/cursor.rs
+++ b/src/providers/cursor.rs
@@ -209,34 +209,55 @@ impl CursorProvider {
     }
 }
 
-/// GROUP BY query to enumerate all conversations with counts and boundary keys.
-/// Only accesses keys (no value I/O), so this is a fast index scan.
+/// Enumerate all conversations with counts and boundary keys.
+/// Only accesses keys (no value I/O), so this is a fast index scan. The
+/// grouping happens in Rust: the ordered scan already delivers all keys of a
+/// conversation contiguously, whereas GROUP BY on a SUBSTR() expression makes
+/// SQLite materialize and sort every key a second time.
 fn query_conv_infos(conn: &Connection, show_last: bool) -> Result<Vec<ConvInfo>> {
-    let order_func = if show_last { "MAX" } else { "MIN" };
-    let query = format!(
-        "SELECT SUBSTR(key, 10, INSTR(SUBSTR(key, 10), ':') - 1) as conv_id, \
-                COUNT(*) as cnt, \
-                MIN(key) as first_key, \
-                {}(key) as preview_key \
-         FROM cursorDiskKV \
+    let mut stmt = conn.prepare(
+        "SELECT key FROM cursorDiskKV \
          WHERE key >= 'bubbleId:' AND key < 'bubbleId;' \
-         GROUP BY conv_id",
-        order_func
-    );
-    let mut stmt = conn.prepare(&query)?;
-    let infos = stmt
-        .query_map([], |row| {
-            Ok(ConvInfo {
-                conv_id: row.get(0)?,
-                bubble_count: row.get::<_, usize>(1)?,
-                first_key: row.get(2)?,
-                preview_key: row.get(3)?,
+         ORDER BY key",
+    )?;
+
+    let mut infos: Vec<ConvInfo> = Vec::new();
+    let mut rows = stmt.query([])?;
+    while let Some(row) = rows.next()? {
+        let Ok(key) = row.get_ref(0)?.as_str() else {
+            continue;
+        };
+        let Some(conv_id) = conv_id_from_bubble_key(key) else {
+            continue;
+        };
+
+        match infos.last_mut() {
+            Some(info) if info.conv_id == conv_id => {
+                info.bubble_count += 1;
+                // MIN(key) is the first key of the group; MAX(key) the last.
+                if show_last {
+                    info.preview_key.clear();
+                    info.preview_key.push_str(key);
+                }
+            }
+            _ => infos.push(ConvInfo {
+                conv_id: conv_id.to_string(),
+                bubble_count: 1,
+                first_key: key.to_string(),
+                preview_key: key.to_string(),
                 user_preview_key: None,
-            })
-        })?
-        .filter_map(|r| r.ok())
-        .collect();
+            }),
+        }
+    }
+
     Ok(infos)
+}
+
+/// Extract `<conv_id>` from a `bubbleId:<conv_id>:<bubble_id>` key.
+fn conv_id_from_bubble_key(key: &str) -> Option<&str> {
+    let rest = key.strip_prefix("bubbleId:")?;
+    let colon = rest.find(':')?;
+    Some(&rest[..colon]).filter(|conv_id| !conv_id.is_empty())
 }
 
 /// Query for the first/last user-type bubble per conversation using json_extract.
@@ -343,6 +364,43 @@ fn query_user_key_for_conv(
     result.unwrap_or((None, None))
 }
 
+/// Resolve user bubble keys for many conversations, in parallel across
+/// read-only connections when the database can be reopened by path.
+/// Returns (conv_id, min_user_key, max_user_key) tuples; conversations whose
+/// chunk failed are simply absent.
+fn query_user_keys_for_convs(
+    db_path: &Path,
+    fallback_conn: &Connection,
+    conv_ids: &[String],
+) -> Vec<(String, Option<String>, Option<String>)> {
+    if conv_ids.len() <= 4 || open_global_ro(db_path).is_none() {
+        return conv_ids
+            .iter()
+            .map(|conv_id| {
+                let (min_key, max_key) = query_user_key_for_conv(fallback_conn, conv_id);
+                (conv_id.clone(), min_key, max_key)
+            })
+            .collect();
+    }
+
+    conv_ids
+        .par_chunks(32)
+        .filter_map(|chunk| {
+            let conn = open_global_ro(db_path)?;
+            Some(
+                chunk
+                    .iter()
+                    .map(|conv_id| {
+                        let (min_key, max_key) = query_user_key_for_conv(&conn, conv_id);
+                        (conv_id.clone(), min_key, max_key)
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .flatten()
+        .collect()
+}
+
 /// Batch-insert user bubble key entries into the cache in a single transaction.
 fn save_user_keys_to_cache(
     cache_conn: &Connection,
@@ -439,25 +497,72 @@ fn build_full_text_map(
     conv_infos: &[ConvInfo],
     cache_conn: Option<&Connection>,
 ) -> HashMap<String, String> {
-    let mut full_text_map = HashMap::with_capacity(conv_infos.len());
-
     let cached = cache_conn
         .map(|c| load_cached_full_text(c))
         .unwrap_or_default();
+    build_full_text_map_from_cached(None, cursor_conn, conv_infos, &cached, cache_conn)
+}
 
-    let mut new_entries: Vec<(String, String, usize)> = Vec::new();
+/// Like `build_full_text_map`, but with cache entries preloaded (so the cache
+/// read can happen on another thread) and, when `parallel_db_path` is given,
+/// cache misses fetched in parallel across read-only connections.
+fn build_full_text_map_from_cached(
+    parallel_db_path: Option<&Path>,
+    cursor_conn: &Connection,
+    conv_infos: &[ConvInfo],
+    cached: &HashMap<String, (String, usize)>,
+    cache_conn: Option<&Connection>,
+) -> HashMap<String, String> {
+    let mut full_text_map = HashMap::with_capacity(conv_infos.len());
+    let mut misses: Vec<&ConvInfo> = Vec::new();
 
     for info in conv_infos {
-        if let Some((text, count)) = cached.get(&info.conv_id) {
-            if *count == info.bubble_count {
+        match cached.get(&info.conv_id) {
+            Some((text, count)) if *count == info.bubble_count => {
                 full_text_map.insert(info.conv_id.clone(), text.clone());
-                continue;
             }
+            // Cache miss or stale — query fresh
+            _ => misses.push(info),
         }
-        // Cache miss or stale — query fresh
-        let text = query_full_text_for_conv(cursor_conn, &info.conv_id);
-        full_text_map.insert(info.conv_id.clone(), text.clone());
-        new_entries.push((info.conv_id.clone(), text, info.bubble_count));
+    }
+
+    let parallel = parallel_db_path
+        .filter(|path| misses.len() > 2 && open_global_ro(path).is_some())
+        .map(Path::to_path_buf);
+    let new_entries: Vec<(String, String, usize)> = match parallel {
+        Some(db_path) => misses
+            .par_chunks(32)
+            .filter_map(|chunk| {
+                let conn = open_global_ro(&db_path)?;
+                Some(
+                    chunk
+                        .iter()
+                        .map(|info| {
+                            (
+                                info.conv_id.clone(),
+                                query_full_text_for_conv(&conn, &info.conv_id),
+                                info.bubble_count,
+                            )
+                        })
+                        .collect::<Vec<_>>(),
+                )
+            })
+            .flatten()
+            .collect(),
+        None => misses
+            .iter()
+            .map(|info| {
+                (
+                    info.conv_id.clone(),
+                    query_full_text_for_conv(cursor_conn, &info.conv_id),
+                    info.bubble_count,
+                )
+            })
+            .collect(),
+    };
+
+    for (conv_id, text, _) in &new_entries {
+        full_text_map.insert(conv_id.clone(), text.clone());
     }
 
     if let Some(cache) = cache_conn {
@@ -465,6 +570,49 @@ fn build_full_text_map(
     }
 
     full_text_map
+}
+
+/// Open an additional read-only connection to the global database so
+/// independent queries can run in parallel. Returns None for databases that
+/// can't be reopened by path (e.g. in-memory databases in tests).
+fn open_global_ro(db_path: &Path) -> Option<Connection> {
+    if !db_path.is_file() {
+        return None;
+    }
+    Connection::open_with_flags(
+        db_path,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .ok()
+}
+
+/// Batch-fetch bubble values in parallel across read-only connections.
+/// Falls back to the single supplied connection when the database can't be
+/// reopened by path. Chunks that fail to fetch are skipped rather than
+/// failing the whole load.
+fn batch_fetch_bubbles_parallel(
+    db_path: &Path,
+    fallback_conn: &Connection,
+    keys: &[String],
+) -> Result<HashMap<String, Value>> {
+    const CHUNK: usize = 200;
+    if keys.len() <= CHUNK || open_global_ro(db_path).is_none() {
+        return batch_fetch_bubbles(fallback_conn, keys);
+    }
+
+    let maps: Vec<HashMap<String, Value>> = keys
+        .par_chunks(CHUNK)
+        .filter_map(|chunk| {
+            let conn = open_global_ro(db_path)?;
+            batch_fetch_bubbles(&conn, chunk).ok()
+        })
+        .collect();
+
+    let mut merged = HashMap::with_capacity(keys.len());
+    for map in maps {
+        merged.extend(map);
+    }
+    Ok(merged)
 }
 
 /// Batch-fetch bubble values by key using IN clauses.
@@ -783,10 +931,28 @@ impl super::Provider for CursorProvider {
                 }
             };
 
-            let workspace_map = provider.build_workspace_map();
+            // The workspace map (hundreds of per-workspace databases) and the
+            // sidecar cache are independent of the global-database queries
+            // below — load them on their own threads so their I/O overlaps
+            // the scans of the (multi-GB) global database.
+            let workspace_handle = std::thread::spawn(move || provider.build_workspace_map());
+            let cache_handle = std::thread::spawn(|| {
+                let cache_conn = open_cache_db();
+                let user_keys = cache_conn
+                    .as_ref()
+                    .map(load_cached_user_keys)
+                    .unwrap_or_default();
+                let full_text = cache_conn
+                    .as_ref()
+                    .map(load_cached_full_text)
+                    .unwrap_or_default();
+                (cache_conn, user_keys, full_text)
+            });
+
             let index_timestamps = load_index_timestamps(&conn);
 
-            // Enumerate all conversations via GROUP BY (fast index scan, ~30ms).
+            // Enumerate all conversations via GROUP BY (index scan over every
+            // bubble key; the most expensive single query in this pipeline).
             let mut conv_infos = match query_conv_infos(&conn, show_last) {
                 Ok(infos) => infos,
                 Err(_) => {
@@ -795,35 +961,44 @@ impl super::Provider for CursorProvider {
                 }
             };
 
+            let (cache_conn, cached_user_keys, cached_full_text) = cache_handle
+                .join()
+                .unwrap_or_else(|_| (None, HashMap::new(), HashMap::new()));
+
             // Resolve user_preview_keys from cache BEFORE splitting into phases.
             // On warm cache this fills all keys, so every conversation builds in the
             // first batch — no visible refresh when phase 2 arrives.
-            let cache_conn = open_cache_db();
-            if let Some(ref cache) = cache_conn {
-                let cached = load_cached_user_keys(cache);
-                for info in &mut conv_infos {
-                    if let Some((min_key, max_key)) = cached.get(&info.conv_id) {
-                        info.user_preview_key = if show_last {
-                            max_key.clone()
-                        } else {
-                            min_key.clone()
-                        };
-                    }
+            for info in &mut conv_infos {
+                if let Some((min_key, max_key)) = cached_user_keys.get(&info.conv_id) {
+                    info.user_preview_key = if show_last {
+                        max_key.clone()
+                    } else {
+                        min_key.clone()
+                    };
                 }
             }
 
             // Batch-fetch all keys we know about (first, preview, and cached user keys).
             let phase1_keys = collect_keys_to_fetch(&conv_infos);
-            let bubble_map = match batch_fetch_bubbles(&conn, &phase1_keys) {
-                Ok(m) => m,
-                Err(_) => {
-                    let _ = tx.send(LoaderMessage::Done);
-                    return;
-                }
-            };
+            let bubble_map =
+                match batch_fetch_bubbles_parallel(&global_db_path, &conn, &phase1_keys) {
+                    Ok(m) => m,
+                    Err(_) => {
+                        let _ = tx.send(LoaderMessage::Done);
+                        return;
+                    }
+                };
 
             // Build full-text search index for all conversations (cached, sub-ms per miss).
-            let full_text_map = build_full_text_map(&conn, &conv_infos, cache_conn.as_ref());
+            let full_text_map = build_full_text_map_from_cached(
+                Some(&global_db_path),
+                &conn,
+                &conv_infos,
+                &cached_full_text,
+                cache_conn.as_ref(),
+            );
+
+            let workspace_map = workspace_handle.join().unwrap_or_default();
 
             // Phase 1: build every conversation we can (includes cached user keys).
             let mut phase1_convs = Vec::new();
@@ -850,15 +1025,27 @@ impl super::Provider for CursorProvider {
             // Phase 2: resolve uncached conversations (cold cache or new conversations).
             if !remaining_infos.is_empty() {
                 if let Some(ref cache) = cache_conn {
+                    let conv_ids: Vec<String> = remaining_infos
+                        .iter()
+                        .map(|info| info.conv_id.clone())
+                        .collect();
+                    let resolved: HashMap<String, (Option<String>, Option<String>)> =
+                        query_user_keys_for_convs(&global_db_path, &conn, &conv_ids)
+                            .into_iter()
+                            .map(|(conv_id, min_key, max_key)| (conv_id, (min_key, max_key)))
+                            .collect();
+
                     let mut new_entries: Vec<(String, Option<String>, Option<String>)> = Vec::new();
                     for info in &mut remaining_infos {
-                        let (min_key, max_key) = query_user_key_for_conv(&conn, &info.conv_id);
+                        let Some((min_key, max_key)) = resolved.get(&info.conv_id) else {
+                            continue;
+                        };
                         info.user_preview_key = if show_last {
                             max_key.clone()
                         } else {
                             min_key.clone()
                         };
-                        new_entries.push((info.conv_id.clone(), min_key, max_key));
+                        new_entries.push((info.conv_id.clone(), min_key.clone(), max_key.clone()));
                     }
                     save_user_keys_to_cache(cache, &new_entries);
                 } else {
@@ -877,7 +1064,9 @@ impl super::Provider for CursorProvider {
 
                 let mut full_map = bubble_map;
                 if !extra_keys.is_empty() {
-                    if let Ok(extra) = batch_fetch_bubbles(&conn, &extra_keys) {
+                    if let Ok(extra) =
+                        batch_fetch_bubbles_parallel(&global_db_path, &conn, &extra_keys)
+                    {
                         full_map.extend(extra);
                     }
                 }

--- a/src/providers/cursor_agent.rs
+++ b/src/providers/cursor_agent.rs
@@ -3,8 +3,8 @@ use crate::claude::{
 };
 use crate::cli::DebugLevel;
 use crate::conversation_index::{
-    CachedFileConversation, SourceFingerprint, attach_search_cache, delete_conversation,
-    fingerprint_from_metadata, load_provider_cache, save_conversations,
+    CachedFileConversation, SourceFingerprint, delete_conversation, fingerprint_from_metadata,
+    load_provider_cache, save_conversations,
 };
 use crate::debug;
 use crate::error::{AppError, Result};
@@ -20,6 +20,7 @@ use std::fs::{self, File};
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Mutex;
 use std::sync::mpsc::{self, Receiver};
 use std::time::SystemTime;
 
@@ -157,13 +158,16 @@ impl CursorAgentProvider {
         Ok(projects)
     }
 
+    /// Load one project's transcripts. Returns the conversations plus clones of
+    /// the freshly parsed ones (cache misses) so the caller can persist them in
+    /// a single batch at the end of the run.
     fn load_project_conversations(
         &self,
         project: &AgentProject,
         show_last: bool,
         debug_level: Option<DebugLevel>,
-        cache: &HashMap<PathBuf, CachedFileConversation>,
-    ) -> Vec<Conversation> {
+        cache: &Mutex<HashMap<PathBuf, CachedFileConversation>>,
+    ) -> (Vec<Conversation>, Vec<(Conversation, SourceFingerprint)>) {
         let workspace_path = project.workspace_path.clone();
         let project_dir_name = project.project_dir_name.clone();
         let loaded: Vec<ConversationLoad> = project
@@ -179,8 +183,10 @@ impl CursorAgentProvider {
 
                 if let Some(fingerprint) = fingerprint
                     && let Some(conversation) = cache
-                        .get(path)
-                        .and_then(|cached| cached.conversation_if_fresh(fingerprint))
+                        .lock()
+                        .ok()
+                        .and_then(|mut cache| cache.remove(path))
+                        .and_then(|cached| cached.into_conversation_if_fresh(fingerprint))
                 {
                     debug::debug(
                         debug_level,
@@ -196,7 +202,7 @@ impl CursorAgentProvider {
                     project_dir_name.clone(),
                     debug_level,
                 ) {
-                    Ok(Some(mut conversation)) => {
+                    Ok(Some(conversation)) => {
                         debug::debug(
                             debug_level,
                             &format!(
@@ -204,7 +210,6 @@ impl CursorAgentProvider {
                                 filename, conversation.preview
                             ),
                         );
-                        attach_search_cache(&mut conversation);
                         match fingerprint {
                             Some(fingerprint) => {
                                 Some(ConversationLoad::Fresh(conversation, fingerprint))
@@ -227,16 +232,15 @@ impl CursorAgentProvider {
             })
             .collect();
 
-        save_conversations(
-            ProviderKind::CursorAgent,
-            show_last,
-            loaded.iter().filter_map(|loaded| match loaded {
+        let fresh: Vec<(Conversation, SourceFingerprint)> = loaded
+            .iter()
+            .filter_map(|loaded| match loaded {
                 ConversationLoad::Fresh(conversation, fingerprint) => {
-                    Some((conversation, *fingerprint))
+                    Some((conversation.clone(), *fingerprint))
                 }
                 ConversationLoad::Cached(_) => None,
-            }),
-        );
+            })
+            .collect();
 
         let mut conversations: Vec<Conversation> = loaded
             .into_iter()
@@ -247,7 +251,7 @@ impl CursorAgentProvider {
         for (idx, conversation) in conversations.iter_mut().enumerate() {
             conversation.index = idx;
         }
-        conversations
+        (conversations, fresh)
     }
 }
 
@@ -274,13 +278,23 @@ impl super::Provider for CursorAgentProvider {
             return Ok(Vec::new());
         }
 
-        let cache = load_provider_cache(ProviderKind::CursorAgent, show_last);
-        let mut conversations: Vec<Conversation> = projects
-            .iter()
-            .flat_map(|project| {
-                self.load_project_conversations(project, show_last, debug_level, &cache)
-            })
-            .collect();
+        let cache = Mutex::new(load_provider_cache(ProviderKind::CursorAgent, show_last));
+        let mut all_fresh: Vec<(Conversation, SourceFingerprint)> = Vec::new();
+        let mut conversations: Vec<Conversation> = Vec::new();
+        for project in &projects {
+            let (convs, fresh) =
+                self.load_project_conversations(project, show_last, debug_level, &cache);
+            conversations.extend(convs);
+            all_fresh.extend(fresh);
+        }
+
+        save_conversations(
+            ProviderKind::CursorAgent,
+            show_last,
+            all_fresh
+                .iter()
+                .map(|(conv, fingerprint)| (conv, *fingerprint)),
+        );
 
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         for (idx, conversation) in conversations.iter_mut().enumerate() {
@@ -308,14 +322,26 @@ impl super::Provider for CursorAgentProvider {
                 }
             };
 
-            let cache = load_provider_cache(ProviderKind::CursorAgent, show_last);
+            let cache = Mutex::new(load_provider_cache(ProviderKind::CursorAgent, show_last));
+            let mut all_fresh: Vec<(Conversation, SourceFingerprint)> = Vec::new();
             for project in &projects {
-                let conversations =
+                let (conversations, fresh) =
                     provider.load_project_conversations(project, show_last, debug_level, &cache);
+                all_fresh.extend(fresh);
                 if !conversations.is_empty() {
                     let _ = tx.send(LoaderMessage::Batch(conversations));
                 }
             }
+
+            // All batches are on the channel; persist newly parsed transcripts
+            // in one write transaction instead of one per project.
+            save_conversations(
+                ProviderKind::CursorAgent,
+                show_last,
+                all_fresh
+                    .iter()
+                    .map(|(conv, fingerprint)| (conv, *fingerprint)),
+            );
 
             let _ = tx.send(LoaderMessage::Done);
         });

--- a/src/providers/cursor_agent.rs
+++ b/src/providers/cursor_agent.rs
@@ -4,7 +4,7 @@ use crate::claude::{
 use crate::cli::DebugLevel;
 use crate::conversation_index::{
     CachedFileConversation, SourceFingerprint, delete_conversation, fingerprint_from_metadata,
-    load_provider_cache, save_conversations,
+    load_provider_cache, prune_conversations, save_conversations,
 };
 use crate::debug;
 use crate::error::{AppError, Result};
@@ -113,46 +113,50 @@ impl CursorAgentProvider {
             .parent()
             .map(|cursor_dir| cursor_dir.join("chats"));
 
-        let mut projects = Vec::new();
-        for entry in fs::read_dir(&self.projects_root)? {
-            let entry = entry?;
-            let path = entry.path();
-            if !path.is_dir() {
-                continue;
-            }
+        // Each project costs real I/O: listing transcripts plus the DFS
+        // filesystem probing in resolve_workspace_path. Run them in parallel.
+        let entries: Vec<_> = fs::read_dir(&self.projects_root)?.flatten().collect();
+        let mut projects: Vec<AgentProject> = entries
+            .par_iter()
+            .filter_map(|entry| {
+                let path = entry.path();
+                if !path.is_dir() {
+                    return None;
+                }
 
-            let transcripts_dir = path.join("agent-transcripts");
-            if !transcripts_dir.is_dir() {
-                continue;
-            }
+                let transcripts_dir = path.join("agent-transcripts");
+                if !transcripts_dir.is_dir() {
+                    return None;
+                }
 
-            let transcript_files = collect_transcript_files(&transcripts_dir);
-            if transcript_files.is_empty() {
-                continue;
-            }
+                let transcript_files = collect_transcript_files(&transcripts_dir);
+                if transcript_files.is_empty() {
+                    return None;
+                }
 
-            let modified = transcript_files
-                .iter()
-                .filter_map(|path| file_modified_time(path))
-                .max()
-                .unwrap_or(SystemTime::UNIX_EPOCH);
+                let modified = transcript_files
+                    .iter()
+                    .filter_map(|path| file_modified_time(path))
+                    .max()
+                    .unwrap_or(SystemTime::UNIX_EPOCH);
 
-            let project_dir_name = path
-                .file_name()
-                .and_then(|name| name.to_str())
-                .unwrap_or("")
-                .to_string();
+                let project_dir_name = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("")
+                    .to_string();
 
-            let workspace_path =
-                resolve_workspace_path(&project_dir_name, chats_dir.as_deref());
+                let workspace_path =
+                    resolve_workspace_path(&project_dir_name, chats_dir.as_deref());
 
-            projects.push(AgentProject {
-                project_dir_name,
-                workspace_path,
-                transcript_files,
-                modified,
-            });
-        }
+                Some(AgentProject {
+                    project_dir_name,
+                    workspace_path,
+                    transcript_files,
+                    modified,
+                })
+            })
+            .collect();
 
         projects.sort_by(|a, b| b.modified.cmp(&a.modified));
         Ok(projects)
@@ -296,6 +300,13 @@ impl super::Provider for CursorAgentProvider {
                 .map(|(conv, fingerprint)| (conv, *fingerprint)),
         );
 
+        // Entries no project claimed belong to files that no longer exist.
+        let stale: Vec<PathBuf> = cache
+            .into_inner()
+            .map(|cache| cache.into_keys().collect())
+            .unwrap_or_default();
+        prune_conversations(ProviderKind::CursorAgent, &stale);
+
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
         for (idx, conversation) in conversations.iter_mut().enumerate() {
             conversation.index = idx;
@@ -313,6 +324,12 @@ impl super::Provider for CursorAgentProvider {
         let projects_root = self.projects_root.clone();
 
         std::thread::spawn(move || {
+            // The conversation index read is independent of the filesystem
+            // walk in list_projects — overlap the two.
+            let cache_handle = std::thread::spawn(move || {
+                Mutex::new(load_provider_cache(ProviderKind::CursorAgent, show_last))
+            });
+
             let provider = CursorAgentProvider { projects_root };
             let projects = match provider.list_projects() {
                 Ok(projects) => projects,
@@ -322,7 +339,9 @@ impl super::Provider for CursorAgentProvider {
                 }
             };
 
-            let cache = Mutex::new(load_provider_cache(ProviderKind::CursorAgent, show_last));
+            let cache = cache_handle
+                .join()
+                .unwrap_or_else(|_| Mutex::new(HashMap::new()));
             let mut all_fresh: Vec<(Conversation, SourceFingerprint)> = Vec::new();
             for project in &projects {
                 let (conversations, fresh) =
@@ -342,6 +361,13 @@ impl super::Provider for CursorAgentProvider {
                     .iter()
                     .map(|(conv, fingerprint)| (conv, *fingerprint)),
             );
+
+            // Entries no project claimed belong to files that no longer exist.
+            let stale: Vec<PathBuf> = cache
+                .into_inner()
+                .map(|cache| cache.into_keys().collect())
+                .unwrap_or_default();
+            prune_conversations(ProviderKind::CursorAgent, &stale);
 
             let _ = tx.send(LoaderMessage::Done);
         });

--- a/src/providers/cursor_agent.rs
+++ b/src/providers/cursor_agent.rs
@@ -185,12 +185,12 @@ impl CursorAgentProvider {
                     .to_string();
                 let fingerprint = file_fingerprint(path);
 
-                if let Some(fingerprint) = fingerprint
-                    && let Some(conversation) = cache
-                        .lock()
-                        .ok()
-                        .and_then(|mut cache| cache.remove(path))
-                        .and_then(|cached| cached.into_conversation_if_fresh(fingerprint))
+                // Always consume the cache entry for a file we've seen: whatever
+                // remains in the map afterwards is treated as deleted and pruned,
+                // and a file that merely failed to stat or parse isn't deleted.
+                let cached_entry = cache.lock().ok().and_then(|mut cache| cache.remove(path));
+                if let (Some(fingerprint), Some(cached)) = (fingerprint, cached_entry)
+                    && let Some(conversation) = cached.into_conversation_if_fresh(fingerprint)
                 {
                     debug::debug(
                         debug_level,

--- a/src/tui/viewer.rs
+++ b/src/tui/viewer.rs
@@ -128,7 +128,8 @@ fn render_entry(lines: &mut Vec<RenderedLine>, entry: &LogEntry, options: &Rende
     match entry {
         LogEntry::Summary { .. }
         | LogEntry::FileHistorySnapshot { .. }
-        | LogEntry::System { .. } => {}
+        | LogEntry::System { .. }
+        | LogEntry::Unknown => {}
         LogEntry::Progress { data, .. } => {
             // Handle agent_progress entries (only when show_thinking is enabled)
             if options.show_thinking


### PR DESCRIPTION
## Summary

Startup previously took about a second to display all conversations. On a real history (1,346 conversations across 4 providers) it now fully loads in **~70–95ms**, with cold starts improving the most. Three independent problems compounded into the ~1s:

### 1. The conversation index cache never persisted (`conversation_index.db`)

The on-disk `file_conversations` table could have been created by an older build with a different column set. `CREATE TABLE IF NOT EXISTS` keeps that stale shape, so every INSERT and SELECT failed with "no such column" — and both error paths were silently swallowed. Result: the cache never hit, never saved, and every startup re-parsed all Claude/Codex/Cursor Agent transcripts (130MB of JSONL for Claude alone).

Fixes:
- Validate the column set on open; drop + VACUUM + recreate on drift (self-healing, it's a cache)
- Save once per provider run instead of once per project — per-project saves under rayon raced for the SQLite write lock with no `busy_timeout` and lost their batches to `SQLITE_BUSY`
- `busy_timeout(5s)`, `synchronous=NORMAL` (WAL), skip opening the DB when there's nothing to save, log failures to the debug log
- Move cached conversations out of the map instead of cloning them
- Prune cached rows whose source files disappeared, so the index doesn't grow forever
- Tests now exercise the production save/delete SQL instead of a test-local copy (the divergence is how the drift went unnoticed), plus regression tests for schema drift

### 2. 103MB of phantom "parse errors" per startup

Newer Claude Code JSONL entry types (`attachment`, `ai-title`, `queue-operation`, `permission-mode`, …) failed enum deserialization, and each was recorded as a ParseError with full line content plus context lines — ~103MB built in RAM on every startup, and persisted once the cache worked. They now deserialize as `LogEntry::Unknown` and are skipped like other metadata entries.

Also stopped persisting `search_text_lower`/`search_topic_end` — they're derived in parallel at startup by `precompute_search_text`, and dropping them halves the cache database and its read time.

### 3. Cursor (IDE) provider was the visible long pole (716ms to first batch cold)

It runs against a multi-GB global `state.vscdb` plus one database per workspace, with every step strictly sequential:
- Workspace map and sidecar-cache reads now run on their own threads, overlapping the global database scans
- Conversation enumeration rewritten as an ordered key scan grouped in Rust: `GROUP BY SUBSTR(key, …)` forced SQLite to materialize and sort every bubble key a second time, even though the index scan already delivers a conversation's keys contiguously (61ms → ~20ms warm)
- Preview-bubble fetches, full-text refreshes, and phase-2 user-key lookups parallelized across read-only connections; a failing chunk no longer aborts the whole provider

Cursor Agent CLI: project listing (transcript listing + DFS workspace-path probing) was 87ms of its 93ms — now parallel, with the index read overlapped.

## Measuring

A hidden `--bench-startup` flag drains every provider's streaming loader headlessly and prints first-batch/done timings per provider. Before/after on the same machine and history:

| | first run | steady state |
|---|---|---|
| before | 990 ms | ~200 ms (page cache only; index never worked) |
| after | ~95 ms | ~70–80 ms |

## Testing

- `cargo test` (172 tests), `cargo clippy` (no new warnings), `cargo fmt` on touched code
- Drove the real TUI through a pty: load, type a query, open a conversation, navigate back, quit; also `--local` mode
- Verified the schema migration end-to-end: a drifted 148MB database rebuilt itself to 23MB on next start