### PR TITLE
Replace recency step function with smooth exponential decay

### DIFF
--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -1,5 +1,5 @@
 use crate::history::Conversation;
-use chrono::{DateTime, Duration, Local};
+use chrono::{DateTime, Local};
 use rayon::prelude::*;
 
 /// Size of the "topic window" — the first ~2000 characters of a conversation,
@@ -256,30 +256,33 @@ fn score_text(
     density * recency_multiplier(timestamp, now)
 }
 
-/// Calculate recency multiplier based on age
+/// Recency boost half-life: a conversation this old gets half the boost.
+const RECENCY_HALF_LIFE_DAYS: f64 = 14.0;
+
+/// Maximum recency boost, applied at age zero and decaying smoothly toward 0.
+/// Capped at 1.0 (a 2x multiplier) so recency breaks ties between similarly
+/// relevant conversations instead of overriding topical relevance: per-term
+/// relevance is sqrt-dampened, so a larger boost lets today's passing mention
+/// outrank an older conversation that is actually about the topic.
+const RECENCY_MAX_BOOST: f64 = 1.0;
+
+/// Calculate recency multiplier based on age.
+///
+/// Smooth exponential decay rather than day/week/month steps: step cliffs
+/// reshuffled rankings whenever a conversation aged across a bucket boundary
+/// (an 8-day-old conversation was penalized 25% against a 6-day-old one).
 fn recency_multiplier(timestamp: DateTime<Local>, now: DateTime<Local>) -> f64 {
-    let age = now.signed_duration_since(timestamp);
-
-    // Handle future timestamps (shouldn't happen, but be safe)
-    if age < Duration::zero() {
-        return 3.0;
-    }
-
-    if age < Duration::days(1) {
-        3.0
-    } else if age < Duration::days(7) {
-        2.0
-    } else if age < Duration::days(30) {
-        1.5
-    } else {
-        1.0
-    }
+    // Clamp future timestamps (clock skew) to "now".
+    let age_seconds = now.signed_duration_since(timestamp).num_seconds().max(0);
+    let age_days = age_seconds as f64 / 86_400.0;
+    1.0 + RECENCY_MAX_BOOST * 0.5_f64.powf(age_days / RECENCY_HALF_LIFE_DAYS)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::history::Conversation;
+    use chrono::Duration;
     use std::path::PathBuf;
 
     fn make_conv(text: &str, timestamp: DateTime<Local>) -> Conversation {
@@ -346,31 +349,71 @@ mod tests {
     }
 
     #[test]
-    fn recency_today_gets_highest_multiplier() {
+    fn recency_boost_decays_monotonically() {
         let now = Local::now();
-        let timestamp = now - Duration::hours(1);
-        assert_eq!(recency_multiplier(timestamp, now), 3.0);
+        let m = |days: i64| recency_multiplier(now - Duration::days(days), now);
+        assert!(m(0) > m(1));
+        assert!(m(1) > m(7));
+        assert!(m(7) > m(30));
+        assert!(m(30) > m(90));
+        assert!(m(365) >= 1.0);
     }
 
     #[test]
-    fn recency_this_week_gets_medium_multiplier() {
+    fn recency_boost_is_bounded() {
         let now = Local::now();
-        let timestamp = now - Duration::days(3);
-        assert_eq!(recency_multiplier(timestamp, now), 2.0);
+        assert_eq!(recency_multiplier(now, now), 1.0 + RECENCY_MAX_BOOST);
+        let very_old = recency_multiplier(now - Duration::days(3650), now);
+        assert!(very_old >= 1.0);
+        assert!(very_old < 1.001);
     }
 
     #[test]
-    fn recency_this_month_gets_low_multiplier() {
+    fn recency_halves_the_boost_at_the_half_life() {
         let now = Local::now();
-        let timestamp = now - Duration::days(15);
-        assert_eq!(recency_multiplier(timestamp, now), 1.5);
+        let at_half_life =
+            recency_multiplier(now - Duration::days(RECENCY_HALF_LIFE_DAYS as i64), now);
+        let expected = 1.0 + RECENCY_MAX_BOOST / 2.0;
+        assert!((at_half_life - expected).abs() < 1e-6);
     }
 
     #[test]
-    fn recency_older_gets_base_multiplier() {
+    fn recency_has_no_cliffs() {
         let now = Local::now();
-        let timestamp = now - Duration::days(60);
-        assert_eq!(recency_multiplier(timestamp, now), 1.0);
+        // The old step function dropped the boost 33% between these two ages.
+        let before = recency_multiplier(now - Duration::hours(23), now);
+        let after = recency_multiplier(now - Duration::hours(25), now);
+        assert!(
+            (before - after) / before < 0.01,
+            "aging two hours should barely change the boost: {before} vs {after}"
+        );
+    }
+
+    /// The complaint that motivated smooth decay: a conversation that is
+    /// actually about the topic but fell off the old 30-day cliff lost to a
+    /// conversation from today that mentions the term once in passing.
+    #[test]
+    fn topical_month_old_convo_outranks_recent_passing_mention() {
+        let now = Local::now();
+        let mut convs = vec![
+            make_conv(
+                "grpc retries grpc deadlines grpc pooling grpc keepalive notes",
+                now - Duration::days(35),
+            ),
+            make_conv(
+                &format!(
+                    "planning notes {} grpc might be worth a look",
+                    "filler text ".repeat(70)
+                ),
+                now,
+            ),
+        ];
+        let searchable = precompute_search_text(&mut convs);
+        let results = search(&convs, &searchable, "grpc", now, None);
+        assert_eq!(
+            results[0], 0,
+            "the conversation about grpc should outrank today's passing mention"
+        );
     }
 
     #[test]
@@ -397,10 +440,10 @@ mod tests {
     }
 
     #[test]
-    fn future_timestamp_gets_highest_multiplier() {
+    fn future_timestamp_clamps_to_max_boost() {
         let now = Local::now();
         let timestamp = now + Duration::hours(1);
-        assert_eq!(recency_multiplier(timestamp, now), 3.0);
+        assert_eq!(recency_multiplier(timestamp, now), 1.0 + RECENCY_MAX_BOOST);
     }
 
     #[test]

--- a/src/tui/search.rs
+++ b/src/tui/search.rs
@@ -371,8 +371,10 @@ mod tests {
     #[test]
     fn recency_halves_the_boost_at_the_half_life() {
         let now = Local::now();
-        let at_half_life =
-            recency_multiplier(now - Duration::days(RECENCY_HALF_LIFE_DAYS as i64), now);
+        // Derive the age in seconds so the test stays correct if the constant
+        // is ever changed to a fractional number of days.
+        let half_life = Duration::seconds((RECENCY_HALF_LIFE_DAYS * 86_400.0).round() as i64);
+        let at_half_life = recency_multiplier(now - half_life, now);
         let expected = 1.0 + RECENCY_MAX_BOOST / 2.0;
         assert!((at_half_life - expected).abs() < 1e-6);
     }


### PR DESCRIPTION
## Summary

Search scores are `relevance density x recency multiplier`. The multiplier was a step function — 3.0 under a day, 2.0 under a week, 1.5 under a month, 1.0 beyond — which caused two ranking problems:

1. **Cliffs.** A conversation's rank dropped sharply the moment it aged past a bucket boundary (25% penalty for being 8 days old instead of 6; 33% for crossing the month line), so results reshuffled day to day for no content reason.
2. **Recency overpowered relevance.** Per-term relevance is sqrt-dampened (10 hits contribute ~3.2, 1 hit contributes 1), so the 3x top-end boost let a conversation from today that mentions a term once in passing outrank a month-old conversation that is actually *about* the topic — the main way search felt like it "returned irrelevant entries".

## Change

The multiplier is now `1 + 0.5^(age_days / 14)`: a smooth decay from a 2x ceiling with a 14-day half-life, asymptotic to 1.0. It crosses the old curve at two weeks — recent-week conversations keep a meaningful boost, while the top end no longer dominates topical signal:

| age | old | new |
|----:|----:|----:|
| 0d | 3.00 | 2.00 |
| 1d | 2.00 | 1.95 |
| 3d | 2.00 | 1.86 |
| 7d | 1.50 | 1.71 |
| 14d | 1.50 | 1.50 |
| 21d | 1.50 | 1.35 |
| 30d | 1.00 | 1.23 |
| 60d | 1.00 | 1.05 |

Future timestamps clamp to the ceiling (was: 3.0).

## Testing

- New tests pin the curve's shape: monotonic decay, bounded [1.0, 2.0], half-life exact at 14 days, no cliff across the old day boundary, future-timestamp clamp.
- A ranking regression test encodes the motivating complaint: a 35-day-old conversation about a topic must outrank today's single passing mention (under the old steps it lost 0.77 to 0.56; now it wins 0.66 to 0.51).
- Existing ranking tests (dense-beats-sparse, topical-old-beats-barely-relevant-recent, topic-window weighting) pass unchanged: 175 tests total, clippy and fmt clean.