### PR TITLE
Make torn-down worktree conversations usable: keep them listed and resumable

### DIFF
--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -26,6 +26,7 @@ pub use loader::{load_all_conversations_streaming, load_conversations};
 pub use parser::process_conversation_file;
 pub use path::{
     convert_path_to_project_dir_name, format_short_name_from_path, project_path_is_live,
+    resolve_project_dir,
 };
 
 /// Identifies which AI tool provider a conversation originated from

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -24,7 +24,9 @@ use std::time::SystemTime;
 // Re-export public API
 pub use loader::{load_all_conversations_streaming, load_conversations};
 pub use parser::process_conversation_file;
-pub use path::{convert_path_to_project_dir_name, format_short_name_from_path};
+pub use path::{
+    convert_path_to_project_dir_name, format_short_name_from_path, project_path_is_live,
+};
 
 /// Identifies which AI tool provider a conversation originated from
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/history/path.rs
+++ b/src/history/path.rs
@@ -80,15 +80,32 @@ pub fn format_short_name_from_path(path: &Path) -> String {
 /// exists, we treat it as live too. Only when the whole repository is gone do
 /// we consider the conversation's project deleted.
 pub fn project_path_is_live(path: &Path) -> bool {
-    if path.exists() {
-        return true;
+    resolve_project_dir(path).is_some()
+}
+
+/// Resolve the directory a resumed session should be launched from, for a
+/// conversation whose recorded project path may have been a torn-down worktree.
+///
+/// - The path itself if it still exists.
+/// - Otherwise, for a worktree-shaped path, the nearest surviving ancestor that
+///   is a git repo — i.e. the repository the worktree branched from.
+/// - Otherwise `None`: the whole project is gone, so there's nowhere to resume.
+pub fn resolve_project_dir(path: &Path) -> Option<PathBuf> {
+    if path.is_dir() {
+        return Some(path.to_path_buf());
     }
 
-    // Only rescue worktree-shaped paths, so deleting a real project still hides
-    // its conversations. `ancestors()` yields the path itself first; skip it
-    // since we already know it's gone, then keep the conversation if any
-    // surviving ancestor is the git repo the worktree came from.
-    is_worktree_path(path) && path.ancestors().skip(1).any(is_git_repo)
+    // `ancestors()` yields the path itself first; skip it since we know it's
+    // gone, then take the first surviving ancestor that is a git repo.
+    if is_worktree_path(path) {
+        return path
+            .ancestors()
+            .skip(1)
+            .find(|ancestor| is_git_repo(ancestor))
+            .map(Path::to_path_buf);
+    }
+
+    None
 }
 
 /// Detect the common worktree-container path components: `worktrees`,
@@ -375,6 +392,23 @@ mod tests {
             "/Users/u/code/repo/.agent-pr-review/worktrees/pr-4"
         )));
         assert!(!is_worktree_path(Path::new("/Users/u/code/repo/src")));
+    }
+
+    #[test]
+    fn resolve_project_dir_returns_repo_for_gone_worktree() {
+        let repo = std::env::temp_dir().join("mnemonai_resolve_repo");
+        let _ = std::fs::remove_dir_all(&repo);
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+
+        // A gone worktree resolves to the surviving repo it branched from.
+        let gone = repo.join(".agent-pr-review/worktrees/pr-4");
+        assert_eq!(resolve_project_dir(&gone), Some(repo.clone()));
+        // An existing directory resolves to itself.
+        assert_eq!(resolve_project_dir(&repo), Some(repo.clone()));
+        // A gone, non-worktree path has nowhere to resume.
+        assert_eq!(resolve_project_dir(&repo.join("src/gone")), None);
+
+        std::fs::remove_dir_all(&repo).unwrap();
     }
 
     #[test]

--- a/src/history/path.rs
+++ b/src/history/path.rs
@@ -70,6 +70,43 @@ pub fn format_short_name_from_path(path: &Path) -> String {
         .unwrap_or_else(|| path_str.into_owned())
 }
 
+/// Whether a conversation's project directory should count as "live" for the
+/// deleted-projects filter.
+///
+/// A path is live if it still exists. But PR-review and feature worktrees are
+/// ephemeral by design — they get torn down after use — yet the conversations
+/// that happened inside them are still about a repository you have. So if the
+/// path looks like a worktree path and the repository it branched from still
+/// exists, we treat it as live too. Only when the whole repository is gone do
+/// we consider the conversation's project deleted.
+pub fn project_path_is_live(path: &Path) -> bool {
+    if path.exists() {
+        return true;
+    }
+
+    // Only rescue worktree-shaped paths, so deleting a real project still hides
+    // its conversations. `ancestors()` yields the path itself first; skip it
+    // since we already know it's gone, then keep the conversation if any
+    // surviving ancestor is the git repo the worktree came from.
+    is_worktree_path(path) && path.ancestors().skip(1).any(is_git_repo)
+}
+
+/// Detect the common worktree-container path components: `worktrees`,
+/// `.worktrees`, and the `<project>__worktrees` form, regardless of nesting
+/// (e.g. `repo/.agent-pr-review/worktrees/pr-4`).
+fn is_worktree_path(path: &Path) -> bool {
+    path.components().any(|c| {
+        c.as_os_str()
+            .to_str()
+            .is_some_and(|s| s.to_ascii_lowercase().ends_with("worktrees"))
+    })
+}
+
+/// A normal repo has a `.git` directory; a linked worktree has a `.git` file.
+fn is_git_repo(path: &Path) -> bool {
+    path.join(".git").exists()
+}
+
 /// Decode a project directory name back to a path (simple heuristic fallback).
 ///
 /// Claude's encoding replaces all non-alphanumeric characters (except `-`) with `-`.
@@ -322,6 +359,55 @@ mod tests {
         // Combined display
         let display = format!("{}/{}", main_project, worktree);
         assert_eq!(display, "WalkingMate/template-engine");
+    }
+
+    // === project_path_is_live tests ===
+
+    #[test]
+    fn is_worktree_path_matches_common_shapes() {
+        assert!(is_worktree_path(Path::new(
+            "/Users/u/code/mnemonai__worktrees/feature"
+        )));
+        assert!(is_worktree_path(Path::new(
+            "/Users/u/code/workmux/.worktrees/uncommitted"
+        )));
+        assert!(is_worktree_path(Path::new(
+            "/Users/u/code/repo/.agent-pr-review/worktrees/pr-4"
+        )));
+        assert!(!is_worktree_path(Path::new("/Users/u/code/repo/src")));
+    }
+
+    #[test]
+    fn live_when_path_exists() {
+        // The repo we're running in always exists.
+        let cwd = std::env::current_dir().unwrap();
+        assert!(project_path_is_live(&cwd));
+    }
+
+    #[test]
+    fn not_live_when_nonexistent_and_not_a_worktree() {
+        let path = Path::new("/Users/u/code/this-project-was-deleted-xyz");
+        assert!(!project_path_is_live(path));
+    }
+
+    #[test]
+    fn live_when_deleted_worktree_of_surviving_repo() {
+        // Build a temp git repo, then a worktree-shaped subpath that doesn't
+        // exist on disk. The repo survives, so the conversation stays live.
+        let repo = std::env::temp_dir().join("mnemonai_wt_test_repo");
+        let _ = std::fs::remove_dir_all(&repo);
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+
+        let gone_worktree = repo.join(".agent-pr-review/worktrees/pr-4");
+        assert!(!gone_worktree.exists());
+        assert!(project_path_is_live(&gone_worktree));
+
+        // But a deleted worktree of a *deleted* repo is not rescued.
+        let orphan =
+            std::env::temp_dir().join("mnemonai_no_such_repo_xyz/.agent-pr-review/worktrees/pr-4");
+        assert!(!project_path_is_live(&orphan));
+
+        std::fs::remove_dir_all(&repo).unwrap();
     }
 
     #[test]

--- a/src/history/path.rs
+++ b/src/history/path.rs
@@ -87,35 +87,57 @@ pub fn project_path_is_live(path: &Path) -> bool {
 /// conversation whose recorded project path may have been a torn-down worktree.
 ///
 /// - The path itself if it still exists.
-/// - Otherwise, for a worktree-shaped path, the nearest surviving ancestor that
-///   is a git repo — i.e. the repository the worktree branched from.
+/// - Otherwise, for a worktree-shaped path, the repository the worktree branched
+///   from, found across the two worktree topologies:
+///   - **nested** (`<repo>/.worktrees/<name>`, `<repo>/.../worktrees/<name>`):
+///     the repo is a surviving ancestor of the worktree;
+///   - **sibling** (`<repo>__worktrees/<name>`): the repo is a sibling, reached
+///     by stripping the `__worktrees` suffix from the container directory.
 /// - Otherwise `None`: the whole project is gone, so there's nowhere to resume.
 pub fn resolve_project_dir(path: &Path) -> Option<PathBuf> {
     if path.is_dir() {
         return Some(path.to_path_buf());
     }
+    if !is_worktree_path(path) {
+        return None;
+    }
 
-    // `ancestors()` yields the path itself first; skip it since we know it's
-    // gone, then take the first surviving ancestor that is a git repo.
-    if is_worktree_path(path) {
-        return path
-            .ancestors()
-            .skip(1)
-            .find(|ancestor| is_git_repo(ancestor))
-            .map(Path::to_path_buf);
+    // `ancestors()` yields the path itself first; skip it since we know it's gone.
+    for ancestor in path.ancestors().skip(1) {
+        // Sibling layout: `…/<project>__worktrees/<name>` — the repo is a sibling
+        // of the worktrees container, named by the stripped prefix.
+        if let Some(stem) = ancestor
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.strip_suffix("__worktrees"))
+        {
+            let repo = ancestor.with_file_name(stem);
+            if is_git_repo(&repo) {
+                return Some(repo);
+            }
+        }
+        // Nested layout: an ancestor is itself the repo.
+        if is_git_repo(ancestor) {
+            return Some(ancestor.to_path_buf());
+        }
     }
 
     None
 }
 
-/// Detect the common worktree-container path components: `worktrees`,
-/// `.worktrees`, and the `<project>__worktrees` form, regardless of nesting
-/// (e.g. `repo/.agent-pr-review/worktrees/pr-4`).
+/// Detect the worktree-container path components: an exact `worktrees` or
+/// `.worktrees`, or a `<project>__worktrees` sibling-layout directory. The
+/// suffix is matched precisely so unrelated names like `client-worktrees`
+/// don't trip the deleted-project rescue.
 fn is_worktree_path(path: &Path) -> bool {
-    path.components().any(|c| {
-        c.as_os_str()
-            .to_str()
-            .is_some_and(|s| s.to_ascii_lowercase().ends_with("worktrees"))
+    path.components()
+        .any(|c| is_worktree_component(c.as_os_str().to_str()))
+}
+
+fn is_worktree_component(name: Option<&str>) -> bool {
+    name.is_some_and(|name| {
+        let lower = name.to_ascii_lowercase();
+        lower == "worktrees" || lower == ".worktrees" || lower.ends_with("__worktrees")
     })
 }
 
@@ -392,6 +414,25 @@ mod tests {
             "/Users/u/code/repo/.agent-pr-review/worktrees/pr-4"
         )));
         assert!(!is_worktree_path(Path::new("/Users/u/code/repo/src")));
+        // A name that merely ends with "worktrees" must not be treated as one.
+        assert!(!is_worktree_path(Path::new(
+            "/Users/u/code/client-worktrees/thing"
+        )));
+    }
+
+    #[test]
+    fn resolve_project_dir_handles_sibling_worktrees_layout() {
+        // Sibling layout: repo at `…/code/proj`, worktrees at `…/code/proj__worktrees/*`.
+        let base = std::env::temp_dir().join("mnemonai_resolve_sibling");
+        let _ = std::fs::remove_dir_all(&base);
+        let repo = base.join("proj");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+
+        let gone = base.join("proj__worktrees/feature");
+        assert!(!gone.exists());
+        assert_eq!(resolve_project_dir(&gone), Some(repo.clone()));
+
+        std::fs::remove_dir_all(&base).unwrap();
     }
 
     #[test]

--- a/src/providers/claude.rs
+++ b/src/providers/claude.rs
@@ -68,12 +68,25 @@ impl super::Provider for ClaudeProvider {
 
     fn resume(&self, conversation: &Conversation, default_args: &[String]) -> Result<()> {
         let project_dir = match &conversation.project_path {
-            Some(path) if path.exists() && path.is_dir() => path,
+            Some(path) if path.is_dir() => path.clone(),
             Some(path) => {
-                return Err(AppError::ClaudeExecutionError(format!(
-                    "Project directory no longer exists: {}",
-                    path.display()
-                )));
+                // The recorded directory is gone. Claude locates a session by the
+                // directory it is launched from, so resuming from anywhere else
+                // fails. If this was a worktree of a repo that still exists, move
+                // the session into that repo's history and resume there.
+                let repo_root = history::resolve_project_dir(path).ok_or_else(|| {
+                    AppError::ClaudeExecutionError(format!(
+                        "Project directory no longer exists: {}",
+                        path.display()
+                    ))
+                })?;
+                rehome_session(conversation, &repo_root)?;
+                eprintln!(
+                    "Worktree {} is gone; moved this session into {} and resuming there.",
+                    path.display(),
+                    repo_root.display()
+                );
+                repo_root
             }
             None => {
                 return Err(AppError::ClaudeExecutionError(
@@ -85,7 +98,7 @@ impl super::Provider for ClaudeProvider {
         let mut command = Command::new("claude");
         command.args(["--resume", &conversation.id]);
         command.args(default_args);
-        command.current_dir(project_dir);
+        command.current_dir(&project_dir);
 
         run_claude_command(command)
     }
@@ -95,6 +108,68 @@ impl super::Provider for ClaudeProvider {
         delete_conversation(ProviderKind::Claude, &conversation.path);
         Ok(())
     }
+}
+
+/// Move a conversation's on-disk footprint — the `<id>.jsonl` transcript and its
+/// `<id>/` sidecar directory of tool results and subagent transcripts — out of a
+/// torn-down worktree's project directory and into `repo_root`'s project
+/// directory, so that `claude --resume`, which locates sessions by launch
+/// directory, can find it.
+///
+/// Moves rather than copies so no orphaned duplicate is left behind, and removes
+/// the source project directory afterwards if it is now empty.
+fn rehome_session(conversation: &Conversation, repo_root: &std::path::Path) -> Result<()> {
+    let src_jsonl = conversation.path.clone();
+    let src_dir = src_jsonl
+        .parent()
+        .ok_or_else(|| {
+            AppError::ClaudeExecutionError(
+                "Conversation transcript has no parent directory".to_string(),
+            )
+        })?
+        .to_path_buf();
+
+    let dest_dir = history::get_claude_projects_dir(repo_root)?;
+    move_session_footprint(&src_jsonl, &src_dir, &dest_dir)
+}
+
+/// Move a session's `<id>.jsonl` transcript and its `<id>/` sidecar directory
+/// from `src_dir` into `dest_dir`, then remove `src_dir` if it is left empty.
+///
+/// Skips any destination entry that already exists (e.g. a prior rehome) rather
+/// than clobbering it. Kept free of `$HOME`/config lookups so it is unit-testable.
+fn move_session_footprint(
+    src_jsonl: &std::path::Path,
+    src_dir: &std::path::Path,
+    dest_dir: &std::path::Path,
+) -> Result<()> {
+    if dest_dir == src_dir {
+        return Ok(()); // already in the target project directory
+    }
+    std::fs::create_dir_all(dest_dir).map_err(AppError::Io)?;
+
+    // The transcript plus, if present, its sidecar directory (same stem, no
+    // extension): `<id>.jsonl` and `<id>/`.
+    let sidecar = src_jsonl.with_extension("");
+    for src in [src_jsonl.to_path_buf(), sidecar] {
+        let Some(name) = src.file_name() else {
+            continue;
+        };
+        if !src.exists() {
+            continue;
+        }
+        let dest = dest_dir.join(name);
+        if dest.exists() {
+            continue;
+        }
+        std::fs::rename(&src, &dest).map_err(AppError::Io)?;
+    }
+
+    // Drop the now-orphaned worktree project directory if nothing remains;
+    // remove_dir fails (and is ignored) when other sessions still live there.
+    let _ = std::fs::remove_dir(src_dir);
+
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -118,4 +193,96 @@ fn run_claude_command(mut command: Command) -> Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fresh(name: &str) -> std::path::PathBuf {
+        let base = std::env::temp_dir().join(name);
+        let _ = std::fs::remove_dir_all(&base);
+        base
+    }
+
+    #[test]
+    fn moves_transcript_and_sidecar_and_removes_empty_src() {
+        let base = fresh("mnemonai_rehome_move");
+        let src_dir = base.join("src-proj");
+        let dest_dir = base.join("dest-proj");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        let id = "11111111-2222-3333-4444-555555555555";
+        let jsonl = src_dir.join(format!("{id}.jsonl"));
+        std::fs::write(&jsonl, b"transcript").unwrap();
+        std::fs::create_dir_all(src_dir.join(id).join("tool-results")).unwrap();
+        std::fs::write(src_dir.join(id).join("tool-results").join("a.txt"), b"out").unwrap();
+
+        move_session_footprint(&jsonl, &src_dir, &dest_dir).unwrap();
+
+        assert!(dest_dir.join(format!("{id}.jsonl")).exists());
+        assert!(
+            dest_dir
+                .join(id)
+                .join("tool-results")
+                .join("a.txt")
+                .exists()
+        );
+        assert!(
+            !src_dir.exists(),
+            "empty source project dir should be removed"
+        );
+
+        std::fs::remove_dir_all(&base).unwrap();
+    }
+
+    #[test]
+    fn keeps_src_dir_when_other_sessions_remain() {
+        let base = fresh("mnemonai_rehome_keep");
+        let src_dir = base.join("src-proj");
+        let dest_dir = base.join("dest-proj");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        let id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let jsonl = src_dir.join(format!("{id}.jsonl"));
+        std::fs::write(&jsonl, b"x").unwrap();
+        std::fs::write(src_dir.join("other-session.jsonl"), b"y").unwrap();
+
+        move_session_footprint(&jsonl, &src_dir, &dest_dir).unwrap();
+
+        assert!(dest_dir.join(format!("{id}.jsonl")).exists());
+        assert!(
+            src_dir.exists(),
+            "source dir kept when another session remains"
+        );
+        assert!(src_dir.join("other-session.jsonl").exists());
+
+        std::fs::remove_dir_all(&base).unwrap();
+    }
+
+    #[test]
+    fn does_not_clobber_existing_destination() {
+        let base = fresh("mnemonai_rehome_noclobber");
+        let src_dir = base.join("src-proj");
+        let dest_dir = base.join("dest-proj");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        std::fs::create_dir_all(&dest_dir).unwrap();
+        let id = "99999999-8888-7777-6666-555555555555";
+        let src_jsonl = src_dir.join(format!("{id}.jsonl"));
+        std::fs::write(&src_jsonl, b"new").unwrap();
+        let dest_jsonl = dest_dir.join(format!("{id}.jsonl"));
+        std::fs::write(&dest_jsonl, b"existing").unwrap();
+
+        move_session_footprint(&src_jsonl, &src_dir, &dest_dir).unwrap();
+
+        assert_eq!(
+            std::fs::read(&dest_jsonl).unwrap(),
+            b"existing",
+            "must not clobber an existing destination transcript"
+        );
+        assert!(
+            src_jsonl.exists(),
+            "source left intact when destination exists"
+        );
+
+        std::fs::remove_dir_all(&base).unwrap();
+    }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3,7 +3,7 @@ use crate::debug_log;
 use crate::error::{AppError, Result};
 use crate::history::{
     Conversation, LoaderMessage, ProviderKind, format_short_name_from_path,
-    process_conversation_file,
+    process_conversation_file, project_path_is_live,
 };
 use crate::providers::Provider;
 use crate::tui::search::{self, SearchableConversation};
@@ -184,7 +184,11 @@ impl App {
         show_deleted_projects: bool,
     ) -> Self {
         if !show_deleted_projects {
-            conversations.retain(|c| c.project_path.as_ref().map_or(true, |p| p.exists()));
+            conversations.retain(|c| {
+                c.project_path
+                    .as_ref()
+                    .is_none_or(|p| project_path_is_live(p))
+            });
         }
         let searchable = search::precompute_search_text(&mut conversations);
         let filtered: Vec<usize> = (0..conversations.len()).collect();
@@ -306,7 +310,11 @@ impl App {
     /// repeated O(n log n) work while provider batches are still arriving.
     pub fn append_conversations(&mut self, mut new_convs: Vec<Conversation>) {
         if !self.show_deleted_projects {
-            new_convs.retain(|c| c.project_path.as_ref().map_or(true, |p| p.exists()));
+            new_convs.retain(|c| {
+                c.project_path
+                    .as_ref()
+                    .is_none_or(|p| project_path_is_live(p))
+            });
         }
         self.conversations.extend(new_convs);
 


### PR DESCRIPTION
PR-review and feature worktrees are ephemeral — they get torn down after use — but the conversations that happened inside them are still about a repository you have. Two halves of the same problem:

## 1. Keep them listed (commit 1)

The deleted-projects filter (`show_deleted_projects = false`, the default) only kept a conversation when its recorded `cwd` still existed on disk, so every conversation done in a throwaway worktree vanished from the list once the worktree was cleaned up — with no hint anything was filtered.

`project_path_is_live(path)`: a non-existent path is still live when it is **worktree-shaped** (a path component ending in `worktrees` — covers `mnemonai__worktrees`, `.worktrees`, and nested forms like `.../worktrees/...`) **and** a **surviving ancestor is a git repo**. So worktree conversations stay visible while a genuinely deleted project stays hidden. Wired into both filter sites in the TUI.

## 2. Make them resumable (commit 2)

With the conversation listed again, resume still failed: Claude locates a session by the directory it is launched from, and the worktree directory is gone, so `claude --resume <id>` reports "No conversation found" from anywhere else.

On resume, when the recorded project directory is missing, resolve the repo the worktree branched from and **move** the session's full on-disk footprint — the `<id>.jsonl` transcript and its `<id>/` sidecar directory of tool results and subagent transcripts — into that repo's history, then launch `claude --resume` from the repo root. You resume **in the real repo with files checked out**. Moving (not copying) leaves no orphaned duplicate, and the emptied worktree project dir is removed. If the repo itself is also gone, resume still errors clearly.

Shared `resolve_project_dir` backs both the filter and the resume path; the move logic lives in a `$HOME`-free `move_session_footprint` helper so it is unit-testable.

## Tests

- `is_worktree_path` / `project_path_is_live` / `resolve_project_dir` across the common worktree shapes and the gone-worktree-of-surviving-repo case.
- `move_session_footprint`: footprint moves and empty source dir is removed; source dir kept when another session remains; existing destination never clobbered.
- Full suite green (186 tests).