### PR TITLE
Add headless list and show commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,16 +42,72 @@ mnemonai --local
 
 ## Headless Usage
 
+Stable, non-interactive commands for tools and skills that want to analyze
+structured conversation data instead of scraping the TUI.
+
 ```bash
-# List all conversations as JSON
+# List all conversations as a JSON array
 mnemonai list --json
 
-# Stream conversation summaries as JSONL
+# Stream conversation summaries as JSONL (one object per line)
 mnemonai list --jsonl --provider codex --limit 100
 
-# Show one conversation by ID or source path
-mnemonai show <session-id> --json
+# Show one conversation by session ID or source path
+mnemonai show <session-id-or-path> --json
+
+# Skill-style pipeline
+mnemonai list --jsonl --limit 500 | jq -r 'select(.message_count > 50) | .id'
 ```
+
+`list` and `show` accept `--provider <claude|codex|cursor|cursor-agent>`,
+`--local` (current directory only), and `--show-deleted-projects`. `list` also
+takes `--limit <n>`. Output is JSON by default; on errors (no match, ambiguous
+target) the command prints a message to stderr and exits non-zero.
+
+### `list` output — conversation summary
+
+Each conversation is an object with these fields (nullable fields are omitted
+when empty):
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `provider` | string | `claude` \| `codex` \| `cursor` \| `cursor-agent` |
+| `id` | string | session ID (use with `show`) |
+| `path` | string | absolute source path |
+| `timestamp` | string | RFC 3339 |
+| `project_name` | string? | |
+| `project_path` | string? | |
+| `cwd` | string? | |
+| `preview` | string | short text preview |
+| `summary` | string? | title, when available |
+| `model` | string? | when available |
+| `message_count` | number | |
+| `total_tokens` | number | |
+| `duration_minutes` | number? | |
+| `parse_errors` | array | diagnostics; entries can include raw transcript lines, so this may be large for broken transcripts |
+
+### `show` output — conversation detail
+
+`{ "conversation": <summary>, "messages": [<message>, ...] }`, where each message
+carries `role` plus whichever of these apply (absent fields are omitted):
+
+| Field | Populated for |
+|-------|---------------|
+| `role` | always — one of `summary`, `user`, `assistant`, `tool_call`, `tool_result`, `thinking`, `image`, `system`, or `agent_<type>` for sub-agent turns |
+| `timestamp` | most messages (RFC 3339) |
+| `text` | text messages, tool results, summaries |
+| `tool_name` | `tool_call` |
+| `tool_input` | `tool_call` — raw, tool-specific JSON (opaque) |
+| `tool_result` | `tool_result` — raw, provider-specific JSON (opaque) |
+| `thinking` | `thinking` |
+| `model` | assistant/thinking, when available |
+| `agent_id` | sub-agent messages |
+| `subtype` / `level` / `duration_ms` | `system` |
+| `source` | `image` — raw provider-specific image source (opaque) |
+
+`tool_input`, `tool_result`, and `source` are passed through verbatim from the
+underlying transcript; treat their inner shape as opaque rather than a stable
+contract.
 
 ## Keyboard Shortcuts
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ mnemonai
 mnemonai --local
 ```
 
+## Headless Usage
+
+```bash
+# List all conversations as JSON
+mnemonai list --json
+
+# Stream conversation summaries as JSONL
+mnemonai list --jsonl --provider codex --limit 100
+
+# Show one conversation by ID or source path
+mnemonai show <session-id> --json
+```
+
 ## Keyboard Shortcuts
 
 Press `?` at any time to open the help overlay.

--- a/docs/headless-cli-plan.md
+++ b/docs/headless-cli-plan.md
@@ -1,0 +1,203 @@
+# Headless CLI Plan
+
+## Goal
+
+Add a stable non-interactive CLI surface so tools and Codex skills can analyze
+conversation history across Claude Code, Codex, Cursor Agent CLI, and Cursor IDE
+without scraping the TUI or terminal render output.
+
+The headless interface should reuse the existing provider, parser, cache, and
+search code paths as much as possible. TUI behavior should remain unchanged.
+
+## Current State
+
+`mnemonai` already has partial headless exits:
+
+- `--render <FILE>` renders one JSONL file and exits.
+- `--show-dir` prints the Claude project directory for the current directory.
+- hidden `--bench-startup` prints provider load timings.
+
+Global and local history browsing still enter the TUI before `--plain`,
+`--show-path`, `--show-id`, and `--resume` can produce output. Direct file input
+also opens the single-file TUI viewer.
+
+## Proposed CLI
+
+Use subcommands for new machine-readable behavior while keeping existing flags
+working for interactive usage.
+
+```text
+mnemonai list [--json|--jsonl] [--local] [--provider <name>] [--limit <n>] [--show-deleted-projects]
+mnemonai show <id-or-path> [--json|--jsonl|--plain|--ledger] [--show-tools] [--show-thinking]
+mnemonai dump [--jsonl] [--local] [--provider <name>] [--since <duration>] [--limit <n>]
+mnemonai search <query> [--json|--jsonl] [--local] [--provider <name>] [--limit <n>]
+```
+
+Provider names:
+
+- `claude`
+- `codex`
+- `cursor`
+- `cursor-agent`
+
+Default output for new headless subcommands should be JSON or JSONL only. Human
+rendering can be explicit on `show`.
+
+## Output Model
+
+### Conversation Summary
+
+Used by `list`, `search`, and `dump` metadata.
+
+```json
+{
+  "provider": "codex",
+  "id": "session-id",
+  "path": "/absolute/source/path.jsonl",
+  "timestamp": "2026-06-19T10:12:33-07:00",
+  "project_name": "mnemonai",
+  "project_path": "/Users/bquenin/qube/bquenin/mnemonai",
+  "cwd": "/Users/bquenin/qube/bquenin/mnemonai",
+  "preview": "short preview",
+  "summary": "optional title",
+  "model": "optional model",
+  "message_count": 12,
+  "total_tokens": 123456,
+  "duration_minutes": 18,
+  "parse_errors": []
+}
+```
+
+### Conversation Detail
+
+Used by `show` and `dump --include-messages` if added.
+
+```json
+{
+  "conversation": { "provider": "claude", "id": "session-id" },
+  "messages": [
+    {
+      "role": "user",
+      "timestamp": "2026-06-19T10:12:33-07:00",
+      "text": "message text",
+      "tool_name": null,
+      "tool_input": null,
+      "tool_result": null,
+      "thinking": null
+    }
+  ]
+}
+```
+
+Keep the schema intentionally simple for skill consumption. Include raw source
+path and provider ID so a caller can re-open or resume with existing tools.
+
+## Implementation Phases
+
+### 1. CLI Shape
+
+- Add a `Command` enum to `src/cli.rs`.
+- Preserve current no-subcommand behavior as the interactive default.
+- Keep legacy flags available where they already work.
+- Add provider parsing as a small enum rather than passing raw strings around.
+
+### 2. Shared Loading Layer
+
+- Extract the global/local loading logic currently embedded in `src/main.rs`
+  into reusable functions.
+- Return `Vec<Conversation>` without entering the TUI.
+- Apply the same sorting, indexing, config merging, local filtering, provider
+  filtering, and deleted-project filtering for both TUI and headless commands.
+- Keep streaming loading for the TUI path, but allow headless commands to use
+  synchronous loading unless benchmark data says this is too slow.
+
+### 3. Serialization Layer
+
+- Add `serde::Serialize` support through dedicated DTO structs instead of
+  serializing `Conversation` directly.
+- Convert `ProviderKind` to stable lowercase provider keys.
+- Serialize paths as strings.
+- Keep `parse_errors` available because they are useful for diagnosing broken
+  transcripts.
+
+### 4. Message Normalization
+
+- Add a provider-independent message DTO built from `LogEntry`.
+- Reuse `Provider::read_entries` for `show`.
+- Normalize:
+  - text blocks
+  - tool calls
+  - tool results
+  - thinking blocks
+  - timestamps
+  - assistant model where available
+- Avoid exposing renderer-specific ledger spans in JSON.
+
+### 5. Commands
+
+- `list`: load conversations and output summaries.
+- `show`: resolve by exact path, exact provider/id pair if later supported, or
+  unique ID. Then output detail or explicit human rendering.
+- `dump`: output summaries as JSONL first. Add `--include-messages` only if the
+  first skill use case needs full transcripts in one pass.
+- `search`: reuse `tui::search` scoring so headless search matches TUI ranking.
+
+### 6. Tests
+
+- Unit-test provider enum parsing and JSON DTO serialization.
+- Add command-level integration tests using temporary fixture histories.
+- Cover:
+  - `list --json`
+  - `list --jsonl --provider codex`
+  - `show <path> --json`
+  - `search <term> --json`
+  - local filtering
+  - deleted-project filtering
+  - ambiguous ID errors
+- Keep tests independent of real user history.
+
+### 7. Documentation
+
+- Update `README.md` with a short "Headless Usage" section.
+- Include examples for `jq` and skill-oriented JSONL processing.
+- Document the schema as stable enough for automation.
+
+## Suggested First PR Scope
+
+Keep the first implementation narrow:
+
+1. `mnemonai list --json|--jsonl`
+2. `mnemonai show <path-or-id> --json`
+3. Provider filtering
+4. JSON DTOs and tests
+
+Defer `dump`, `search`, duration parsing like `--since 30d`, and advanced human
+render options until the core shape is proven.
+
+## Risks And Tradeoffs
+
+- Refactoring `main.rs` loading code is worth doing, but it should be scoped to
+  avoid destabilizing the TUI.
+- ID resolution can be ambiguous across providers. The first version should
+  return a clear ambiguity error rather than guessing.
+- Cursor IDE conversations are database-backed, so `show` should continue using
+  the provider abstraction rather than assuming every source is JSONL.
+- JSON output should not depend on terminal width, ANSI colors, markdown
+  rendering, or pager behavior.
+- For very large histories, `dump --include-messages` could be expensive. Start
+  with metadata and add full-message streaming deliberately.
+
+## Skill Integration Pattern
+
+A future analysis skill can call:
+
+```bash
+mnemonai list --jsonl --limit 500
+mnemonai show "$session_id" --json
+mnemonai search "failed tests" --json --limit 50
+```
+
+The skill should analyze structured fields instead of rendered transcript text,
+then report recurring friction such as repeated failed commands, tool errors,
+ambiguous instructions, missing project rules, hook failures, stale scripts, or
+places where a reusable command or repository rule would reduce repeated work.

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -151,6 +151,25 @@ pub fn extract_text_from_assistant(message: &AssistantMessage) -> String {
     extract_text_from_blocks(&message.content)
 }
 
+/// Extract text content from a tool result block.
+///
+/// Returns `Some(text)` when the content is a string or an array of text
+/// blocks (e.g. `[{type: "text", text: "..."}]`), and `None` for JSON
+/// structures that should be pretty-printed instead.
+pub fn extract_tool_result_text(content: Option<&serde_json::Value>) -> Option<String> {
+    match content {
+        Some(serde_json::Value::String(s)) => Some(s.clone()),
+        Some(serde_json::Value::Array(arr)) => {
+            let texts: Vec<&str> = arr
+                .iter()
+                .filter_map(|item| item.get("text").and_then(|t| t.as_str()))
+                .collect();
+            (!texts.is_empty()).then(|| texts.join("\n\n"))
+        }
+        _ => None,
+    }
+}
+
 /// Agent progress data from subagent conversations
 #[derive(Debug, Deserialize, Clone)]
 pub struct AgentProgressData {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,4 @@
+use crate::history::ProviderKind;
 use clap::{Parser, Subcommand, ValueEnum};
 use std::fmt;
 use std::path::PathBuf;
@@ -178,6 +179,18 @@ pub enum ProviderFilter {
     Codex,
     Cursor,
     CursorAgent,
+}
+
+impl ProviderFilter {
+    /// The provider kind this filter selects.
+    pub fn kind(self) -> ProviderKind {
+        match self {
+            ProviderFilter::Claude => ProviderKind::Claude,
+            ProviderFilter::Codex => ProviderKind::Codex,
+            ProviderFilter::Cursor => ProviderKind::Cursor,
+            ProviderFilter::CursorAgent => ProviderKind::CursorAgent,
+        }
+    }
 }
 
 #[derive(Parser, Debug)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, Subcommand, ValueEnum};
 use std::fmt;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -45,6 +45,9 @@ impl fmt::Display for DebugLevel {
 #[command(version)]
 #[command(about = "Universal AI coding conversation history browser")]
 pub struct Args {
+    #[command(subcommand)]
+    pub command: Option<Command>,
+
     /// Show tool calls in the conversation output
     #[arg(long, short = 't', group = "tools_display")]
     pub show_tools: bool,
@@ -158,4 +161,106 @@ pub struct Args {
         conflicts_with_all = ["local", "show_dir", "resume", "show_path", "show_id", "plain", "render"]
     )]
     pub input_file: Option<PathBuf>,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// List conversations without opening the TUI
+    List(ListCommand),
+
+    /// Show one conversation without opening the TUI
+    Show(ShowCommand),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ProviderFilter {
+    Claude,
+    Codex,
+    Cursor,
+    CursorAgent,
+}
+
+#[derive(Parser, Debug)]
+pub struct ListCommand {
+    /// Output a JSON array (default)
+    #[arg(long, group = "headless_list_output")]
+    pub json: bool,
+
+    /// Output one JSON object per line
+    #[arg(long, group = "headless_list_output")]
+    pub jsonl: bool,
+
+    /// Only include conversations from this provider
+    #[arg(long, value_enum)]
+    pub provider: Option<ProviderFilter>,
+
+    /// Only include conversations from the current project directory
+    #[arg(long)]
+    pub local: bool,
+
+    /// Include conversations from deleted project directories
+    #[arg(long)]
+    pub show_deleted_projects: bool,
+
+    /// Limit the number of conversations returned
+    #[arg(long)]
+    pub limit: Option<usize>,
+}
+
+#[derive(Parser, Debug)]
+pub struct ShowCommand {
+    /// Conversation ID or source path
+    pub target: String,
+
+    /// Output structured JSON (default)
+    #[arg(long)]
+    pub json: bool,
+
+    /// Only search conversations from this provider
+    #[arg(long, value_enum)]
+    pub provider: Option<ProviderFilter>,
+
+    /// Only search conversations from the current project directory
+    #[arg(long)]
+    pub local: bool,
+
+    /// Include conversations from deleted project directories
+    #[arg(long)]
+    pub show_deleted_projects: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_list_subcommand() {
+        let args = Args::try_parse_from([
+            "mnemonai",
+            "list",
+            "--jsonl",
+            "--provider",
+            "cursor-agent",
+            "--limit",
+            "10",
+        ])
+        .unwrap();
+
+        match args.command {
+            Some(Command::List(command)) => {
+                assert!(command.jsonl);
+                assert_eq!(command.provider, Some(ProviderFilter::CursorAgent));
+                assert_eq!(command.limit, Some(10));
+            }
+            other => panic!("expected list command, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn keeps_legacy_file_argument_mode() {
+        let args = Args::try_parse_from(["mnemonai", "session.jsonl"]).unwrap();
+
+        assert!(args.command.is_none());
+        assert_eq!(args.input_file, Some(PathBuf::from("session.jsonl")));
+    }
 }

--- a/src/conversation_index.rs
+++ b/src/conversation_index.rs
@@ -100,7 +100,7 @@ where
             )",
         )?;
 
-        let provider_key = provider_key(&provider);
+        let provider_key = provider.key();
         let show_last = i64::from(show_last);
 
         for (conversation, fingerprint) in entries {
@@ -164,7 +164,7 @@ pub fn prune_conversations(provider: ProviderKind, paths: &[PathBuf]) {
     for path in paths {
         let _ = tx.execute(
             "DELETE FROM file_conversations WHERE provider = ?1 AND source_path = ?2",
-            params![provider_key(&provider), path.to_string_lossy()],
+            params![provider.key(), path.to_string_lossy()],
         );
     }
     let _ = tx.commit();
@@ -177,7 +177,7 @@ fn delete_conversation_from_conn(
 ) -> rusqlite::Result<()> {
     conn.execute(
         "DELETE FROM file_conversations WHERE provider = ?1 AND source_path = ?2",
-        params![provider_key(&provider), path.to_string_lossy()],
+        params![provider.key(), path.to_string_lossy()],
     )?;
     Ok(())
 }
@@ -197,11 +197,7 @@ fn load_provider_cache_from_conn(
     )?;
 
     let rows = stmt.query_map(
-        params![
-            SCHEMA_VERSION,
-            provider_key(&provider),
-            i64::from(show_last)
-        ],
+        params![SCHEMA_VERSION, provider.key(), i64::from(show_last)],
         |row| {
             let source_path: String = row.get(0)?;
             let timestamp: String = row.get(4)?;
@@ -362,15 +358,6 @@ fn table_matches_expected_columns(conn: &Connection) -> rusqlite::Result<bool> {
             .iter()
             .map(String::as_str)
             .eq(expected.iter().copied()))
-}
-
-fn provider_key(provider: &ProviderKind) -> &'static str {
-    match provider {
-        ProviderKind::Claude => "claude",
-        ProviderKind::Codex => "codex",
-        ProviderKind::Cursor => "cursor",
-        ProviderKind::CursorAgent => "cursor-agent",
-    }
 }
 
 fn system_time_to_millis(time: SystemTime) -> i64 {

--- a/src/conversation_index.rs
+++ b/src/conversation_index.rs
@@ -3,7 +3,7 @@
 //! File-backed providers use this sidecar database to skip reparsing unchanged
 //! JSONL transcripts and to reuse lowercased search text on warm starts.
 
-use crate::history::{Conversation, ProviderKind};
+use crate::history::{Conversation, ProviderKind, path_to_string};
 use chrono::{DateTime, Local};
 use rusqlite::{Connection, TransactionBehavior, params};
 use std::collections::HashMap;
@@ -119,8 +119,8 @@ where
                 conversation.preview,
                 conversation.full_text,
                 conversation.project_name.as_deref(),
-                path_to_string(conversation.project_path.as_ref()),
-                path_to_string(conversation.cwd.as_ref()),
+                path_to_string(conversation.project_path.as_deref()),
+                path_to_string(conversation.cwd.as_deref()),
                 conversation.message_count as i64,
                 parse_errors_json,
                 conversation.summary.as_deref(),
@@ -364,10 +364,6 @@ fn system_time_to_millis(time: SystemTime) -> i64 {
     time.duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_millis().min(i64::MAX as u128) as i64)
         .unwrap_or(0)
-}
-
-fn path_to_string(path: Option<&PathBuf>) -> Option<String> {
-    path.map(|path| path.to_string_lossy().to_string())
 }
 
 fn optional_path(path: Option<String>) -> Option<PathBuf> {

--- a/src/display.rs
+++ b/src/display.rs
@@ -227,7 +227,11 @@ impl<W: Write + ?Sized> OutputFormatter for LedgerFormatter<'_, W> {
 
     fn format_assistant_text(&mut self, text: &str) {
         let rendered = render_markdown(text, self.content_width);
-        self.print_markdown("Claude", |s| s.custom_color(CLAUDE_TERRACOTTA).bold(), &rendered);
+        self.print_markdown(
+            "Claude",
+            |s| s.custom_color(CLAUDE_TERRACOTTA).bold(),
+            &rendered,
+        );
     }
 
     fn format_tool_call(&mut self, name: &str, input: &serde_json::Value) {
@@ -235,7 +239,11 @@ impl<W: Write + ?Sized> OutputFormatter for LedgerFormatter<'_, W> {
 
         // Print the header with appropriate styling
         let padded_name = format!("{:>width$}", "Claude", width = NAME_WIDTH);
-        let _ = write!(self.writer, "{}", padded_name.custom_color(CLAUDE_TERRACOTTA_DIM));
+        let _ = write!(
+            self.writer,
+            "{}",
+            padded_name.custom_color(CLAUDE_TERRACOTTA_DIM)
+        );
         let _ = write!(self.writer, "{}", SEPARATOR.custom_color(SEPARATOR_COLOR));
 
         // Print the header in subtle gray
@@ -262,7 +270,11 @@ impl<W: Write + ?Sized> OutputFormatter for LedgerFormatter<'_, W> {
     }
 
     fn format_thinking(&mut self, thought: &str) {
-        self.print_lines("Thinking", |s| s.custom_color(CLAUDE_TERRACOTTA_DIM), thought);
+        self.print_lines(
+            "Thinking",
+            |s| s.custom_color(CLAUDE_TERRACOTTA_DIM),
+            thought,
+        );
     }
 
     fn end_message(&mut self) {
@@ -278,7 +290,11 @@ impl<W: Write + ?Sized> OutputFormatter for LedgerFormatter<'_, W> {
     fn format_agent_assistant_text(&mut self, agent_id: &str, text: &str) {
         let rendered = render_markdown(text, self.content_width);
         let name = format!("↳{}", short_agent_id(agent_id));
-        self.print_markdown(&name, |s| s.custom_color(CLAUDE_TERRACOTTA).dimmed(), &rendered);
+        self.print_markdown(
+            &name,
+            |s| s.custom_color(CLAUDE_TERRACOTTA).dimmed(),
+            &rendered,
+        );
     }
 
     fn format_agent_tool_call(&mut self, agent_id: &str, name: &str, input: &serde_json::Value) {
@@ -399,7 +415,6 @@ fn format_tool_content(content: Option<&serde_json::Value>) -> String {
         None => "<no content>".to_string(),
     }
 }
-
 
 /// Get the terminal width, defaulting to 80 if unavailable
 fn get_terminal_width() -> usize {
@@ -773,8 +788,8 @@ pub fn render_to_terminal(file_path: &Path, options: &DisplayOptions) -> Result<
         show_timing: false, // Non-TUI render doesn't support timing toggle
         content_width,
         assistant_label: "Claude".to_string(),
-        assistant_color: (218, 119, 86),      // Claude terracotta
-        assistant_dim_color: (170, 93, 67),   // Claude terracotta dim
+        assistant_color: (218, 119, 86),    // Claude terracotta
+        assistant_dim_color: (170, 93, 67), // Claude terracotta dim
     };
 
     let rendered_lines = render_conversation(file_path, &render_options)?;
@@ -837,4 +852,3 @@ pub fn render_to_terminal(file_path: &Path, options: &DisplayOptions) -> Result<
 
     Ok(())
 }
-

--- a/src/display.rs
+++ b/src/display.rs
@@ -680,8 +680,6 @@ fn process_assistant_message<F: OutputFormatter>(
     }
 }
 
-/// Get a truncated agent ID for display (max 7 characters)
-
 /// Process an agent progress message using the provided formatter
 fn process_agent_message<F: OutputFormatter>(
     formatter: &mut F,

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,9 @@ pub enum AppError {
 
     #[error("Configuration error: {0}")]
     ConfigError(String),
+
+    #[error("{0}")]
+    CommandError(String),
 }
 
 pub type Result<T> = std::result::Result<T, AppError>;

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1,12 +1,17 @@
-use crate::claude::{AgentContent, ContentBlock, LogEntry, UserContent, parse_agent_progress};
+use crate::claude::{
+    AgentContent, ContentBlock, LogEntry, UserContent, extract_tool_result_text,
+    parse_agent_progress,
+};
 use crate::cli::{Command, DebugLevel, ListCommand, ProviderFilter, ShowCommand};
 use crate::error::{AppError, Result};
-use crate::history::{Conversation, LoaderMessage, ParseError, ProviderKind, project_path_is_live};
+use crate::history::{
+    Conversation, LoaderMessage, ParseError, path_to_string, project_path_is_live,
+};
 use crate::providers::Provider;
 use serde::Serialize;
 use serde_json::Value;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 pub struct HeadlessSettings {
     pub cli_local: bool,
@@ -169,7 +174,7 @@ fn load_conversations(
     let local = command_local || settings.cli_local || settings.config_local;
     let show_deleted_projects = command_show_deleted || settings.show_deleted_projects;
     let mut conversations = if local {
-        load_local_conversations(
+        crate::loader::load_local(
             providers,
             settings.show_last,
             settings.debug,
@@ -210,7 +215,7 @@ fn load_global_conversations(
     let mut conversations = Vec::new();
 
     for provider in providers {
-        if !provider_filter_matches(provider_filter, &provider.kind()) {
+        if !crate::loader::provider_filter_matches(provider_filter, &provider.kind()) {
             continue;
         }
 
@@ -227,41 +232,6 @@ fn load_global_conversations(
                     break;
                 }
             }
-        }
-    }
-
-    Ok(conversations)
-}
-
-fn load_local_conversations(
-    providers: &[Box<dyn Provider>],
-    show_last: bool,
-    debug: Option<DebugLevel>,
-    provider_filter: Option<ProviderFilter>,
-) -> Result<Vec<Conversation>> {
-    let current_dir = std::env::current_dir().map_err(|err| {
-        AppError::Io(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!("Failed to get current directory: {}", err),
-        ))
-    })?;
-
-    let mut conversations = Vec::new();
-    for provider in providers {
-        if !provider_filter_matches(provider_filter, &provider.kind()) {
-            continue;
-        }
-
-        if let Ok(mut provider_conversations) = provider.load_conversations(show_last, debug) {
-            if provider.kind() != ProviderKind::Claude {
-                provider_conversations.retain(|conversation| {
-                    conversation
-                        .project_path
-                        .as_ref()
-                        .is_some_and(|path| path == &current_dir)
-                });
-            }
-            conversations.extend(provider_conversations);
         }
     }
 
@@ -334,8 +304,8 @@ impl ConversationSummary {
             path: conversation.path.to_string_lossy().to_string(),
             timestamp: conversation.timestamp.to_rfc3339(),
             project_name: conversation.project_name.clone(),
-            project_path: optional_path_to_string(conversation.project_path.as_ref()),
-            cwd: optional_path_to_string(conversation.cwd.as_ref()),
+            project_path: path_to_string(conversation.project_path.as_deref()),
+            cwd: path_to_string(conversation.cwd.as_deref()),
             preview: conversation.preview.clone(),
             summary: conversation.summary.clone(),
             model: conversation.model.clone(),
@@ -457,7 +427,7 @@ fn push_content_block(
         }
         ContentBlock::ToolResult { content, .. } => {
             let mut message = MessageDto::new("tool_result", timestamp);
-            message.text = tool_result_text(content.as_ref());
+            message.text = extract_tool_result_text(content.as_ref());
             message.tool_result = content.clone();
             message.agent_id = agent_id.map(ToString::to_string);
             messages.push(message);
@@ -495,20 +465,6 @@ fn push_text_message(
     message.model = model.map(ToString::to_string);
     message.agent_id = agent_id.map(ToString::to_string);
     messages.push(message);
-}
-
-fn tool_result_text(content: Option<&Value>) -> Option<String> {
-    match content {
-        Some(Value::String(text)) => Some(text.clone()),
-        Some(Value::Array(items)) => {
-            let texts: Vec<_> = items
-                .iter()
-                .filter_map(|item| item.get("text").and_then(Value::as_str))
-                .collect();
-            (!texts.is_empty()).then(|| texts.join("\n\n"))
-        }
-        _ => None,
-    }
 }
 
 fn json_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>> {
@@ -549,19 +505,13 @@ fn write_stdout(buf: &[u8]) -> Result<()> {
     Ok(())
 }
 
-fn provider_filter_matches(filter: Option<ProviderFilter>, kind: &ProviderKind) -> bool {
-    filter.is_none_or(|filter| &filter.kind() == kind)
-}
-
-fn optional_path_to_string(path: Option<&PathBuf>) -> Option<String> {
-    path.map(|path| path.to_string_lossy().to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::claude::{AssistantMessage, TokenUsage, UserMessage};
+    use crate::history::ProviderKind;
     use chrono::{Local, TimeZone};
+    use std::path::PathBuf;
 
     fn conversation(id: &str, path: &str, provider: ProviderKind) -> Conversation {
         Conversation {
@@ -814,23 +764,6 @@ mod tests {
         let second: Value = serde_json::from_str(lines[1]).unwrap();
         assert_eq!(first["id"], "a");
         assert_eq!(second["id"], "b");
-    }
-
-    #[test]
-    fn provider_filter_matches_expected_kinds() {
-        assert!(provider_filter_matches(None, &ProviderKind::Cursor));
-        assert!(provider_filter_matches(
-            Some(ProviderFilter::Codex),
-            &ProviderKind::Codex
-        ));
-        assert!(!provider_filter_matches(
-            Some(ProviderFilter::Codex),
-            &ProviderKind::Claude
-        ));
-        assert!(provider_filter_matches(
-            Some(ProviderFilter::CursorAgent),
-            &ProviderKind::CursorAgent
-        ));
     }
 
     #[test]

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1,0 +1,663 @@
+use crate::claude::{AgentContent, ContentBlock, LogEntry, UserContent, parse_agent_progress};
+use crate::cli::{Command, DebugLevel, ListCommand, ProviderFilter, ShowCommand};
+use crate::error::{AppError, Result};
+use crate::history::{Conversation, LoaderMessage, ParseError, ProviderKind, project_path_is_live};
+use crate::providers::Provider;
+use serde::Serialize;
+use serde_json::Value;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+pub struct HeadlessSettings {
+    pub cli_local: bool,
+    pub config_local: bool,
+    pub show_last: bool,
+    pub show_deleted_projects: bool,
+    pub debug: Option<DebugLevel>,
+}
+
+#[derive(Serialize)]
+struct ConversationSummary {
+    provider: &'static str,
+    id: String,
+    path: String,
+    timestamp: String,
+    project_name: Option<String>,
+    project_path: Option<String>,
+    cwd: Option<String>,
+    preview: String,
+    summary: Option<String>,
+    model: Option<String>,
+    message_count: usize,
+    total_tokens: u64,
+    duration_minutes: Option<u64>,
+    parse_errors: Vec<ParseError>,
+}
+
+#[derive(Serialize)]
+struct ConversationDetail {
+    conversation: ConversationSummary,
+    messages: Vec<MessageDto>,
+}
+
+#[derive(Serialize)]
+struct MessageDto {
+    role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timestamp: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_input: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    subtype: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration_ms: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source: Option<Value>,
+}
+
+impl MessageDto {
+    fn new(role: impl Into<String>, timestamp: Option<&str>) -> Self {
+        Self {
+            role: role.into(),
+            timestamp: timestamp.map(ToString::to_string),
+            text: None,
+            tool_name: None,
+            tool_input: None,
+            tool_result: None,
+            thinking: None,
+            model: None,
+            agent_id: None,
+            subtype: None,
+            duration_ms: None,
+            source: None,
+        }
+    }
+}
+
+pub fn run_command(
+    command: &Command,
+    providers: &[Box<dyn Provider>],
+    settings: &HeadlessSettings,
+) -> Result<()> {
+    match command {
+        Command::List(command) => run_list(command, providers, settings),
+        Command::Show(command) => run_show(command, providers, settings),
+    }
+}
+
+fn run_list(
+    command: &ListCommand,
+    providers: &[Box<dyn Provider>],
+    settings: &HeadlessSettings,
+) -> Result<()> {
+    let mut conversations = load_conversations(
+        providers,
+        settings,
+        command.provider,
+        command.local,
+        command.show_deleted_projects,
+    )?;
+    if let Some(limit) = command.limit {
+        conversations.truncate(limit);
+    }
+
+    let summaries: Vec<_> = conversations
+        .iter()
+        .map(ConversationSummary::from_conversation)
+        .collect();
+
+    if command.jsonl {
+        write_jsonl(&summaries)
+    } else {
+        write_json(&summaries)
+    }
+}
+
+fn run_show(
+    command: &ShowCommand,
+    providers: &[Box<dyn Provider>],
+    settings: &HeadlessSettings,
+) -> Result<()> {
+    let conversations = load_conversations(
+        providers,
+        settings,
+        command.provider,
+        command.local,
+        command.show_deleted_projects,
+    )?;
+    let conversation = resolve_conversation(&conversations, &command.target)?;
+    let provider = providers
+        .iter()
+        .find(|provider| provider.kind() == conversation.provider)
+        .ok_or_else(|| {
+            AppError::CommandError(format!(
+                "No provider found for {} conversation",
+                provider_key(&conversation.provider)
+            ))
+        })?;
+    let entries = provider.read_entries(conversation)?;
+    let detail = ConversationDetail {
+        conversation: ConversationSummary::from_conversation(conversation),
+        messages: messages_from_entries(&entries),
+    };
+
+    write_json(&detail)
+}
+
+fn load_conversations(
+    providers: &[Box<dyn Provider>],
+    settings: &HeadlessSettings,
+    provider_filter: Option<ProviderFilter>,
+    command_local: bool,
+    command_show_deleted: bool,
+) -> Result<Vec<Conversation>> {
+    let local = command_local || settings.cli_local || settings.config_local;
+    let show_deleted_projects = command_show_deleted || settings.show_deleted_projects;
+    let mut conversations = if local {
+        load_local_conversations(
+            providers,
+            settings.show_last,
+            settings.debug,
+            provider_filter,
+        )?
+    } else {
+        load_global_conversations(
+            providers,
+            settings.show_last,
+            settings.debug,
+            provider_filter,
+        )?
+    };
+
+    if !show_deleted_projects {
+        conversations.retain(|conversation| {
+            conversation
+                .project_path
+                .as_ref()
+                .is_none_or(|path| project_path_is_live(path))
+        });
+    }
+
+    conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    for (idx, conversation) in conversations.iter_mut().enumerate() {
+        conversation.index = idx;
+    }
+
+    Ok(conversations)
+}
+
+fn load_global_conversations(
+    providers: &[Box<dyn Provider>],
+    show_last: bool,
+    debug: Option<DebugLevel>,
+    provider_filter: Option<ProviderFilter>,
+) -> Result<Vec<Conversation>> {
+    let mut conversations = Vec::new();
+
+    for provider in providers {
+        if !provider_filter_matches(provider_filter, &provider.kind()) {
+            continue;
+        }
+
+        let rx = provider.load_conversations_streaming(show_last, debug);
+        for message in rx {
+            match message {
+                LoaderMessage::Batch(mut batch) => conversations.append(&mut batch),
+                LoaderMessage::Done => break,
+                LoaderMessage::ProjectError => {}
+                LoaderMessage::Fatal(error) => {
+                    if provider_filter.is_some() {
+                        return Err(error);
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(conversations)
+}
+
+fn load_local_conversations(
+    providers: &[Box<dyn Provider>],
+    show_last: bool,
+    debug: Option<DebugLevel>,
+    provider_filter: Option<ProviderFilter>,
+) -> Result<Vec<Conversation>> {
+    let current_dir = std::env::current_dir().map_err(|err| {
+        AppError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("Failed to get current directory: {}", err),
+        ))
+    })?;
+
+    let mut conversations = Vec::new();
+    for provider in providers {
+        if !provider_filter_matches(provider_filter, &provider.kind()) {
+            continue;
+        }
+
+        if let Ok(mut provider_conversations) = provider.load_conversations(show_last, debug) {
+            if provider.kind() != ProviderKind::Claude {
+                provider_conversations.retain(|conversation| {
+                    conversation
+                        .project_path
+                        .as_ref()
+                        .is_some_and(|path| path == &current_dir)
+                });
+            }
+            conversations.extend(provider_conversations);
+        }
+    }
+
+    Ok(conversations)
+}
+
+fn resolve_conversation<'a>(
+    conversations: &'a [Conversation],
+    target: &str,
+) -> Result<&'a Conversation> {
+    let target_path = Path::new(target);
+    let target_canonical = target_path.canonicalize().ok();
+
+    let matches: Vec<&Conversation> = conversations
+        .iter()
+        .filter(|conversation| {
+            path_matches(&conversation.path, target_path, target_canonical.as_deref())
+                || conversation.id == target
+                || conversation
+                    .path
+                    .file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .is_some_and(|stem| stem == target)
+        })
+        .collect();
+
+    match matches.as_slice() {
+        [conversation] => Ok(conversation),
+        [] => Err(AppError::CommandError(format!(
+            "No conversation found for target '{}'",
+            target
+        ))),
+        matches => {
+            let rendered = matches
+                .iter()
+                .take(8)
+                .map(|conversation| {
+                    format!(
+                        "{}:{} ({})",
+                        provider_key(&conversation.provider),
+                        conversation.id,
+                        conversation.path.display()
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(AppError::CommandError(format!(
+                "Ambiguous conversation target '{}'; matches: {}",
+                target, rendered
+            )))
+        }
+    }
+}
+
+fn path_matches(path: &Path, target: &Path, target_canonical: Option<&Path>) -> bool {
+    path == target
+        || target_canonical.is_some_and(|canonical| {
+            path.canonicalize()
+                .map(|path| path == canonical)
+                .unwrap_or(false)
+        })
+}
+
+impl ConversationSummary {
+    fn from_conversation(conversation: &Conversation) -> Self {
+        Self {
+            provider: provider_key(&conversation.provider),
+            id: conversation.id.clone(),
+            path: conversation.path.to_string_lossy().to_string(),
+            timestamp: conversation.timestamp.to_rfc3339(),
+            project_name: conversation.project_name.clone(),
+            project_path: optional_path_to_string(conversation.project_path.as_ref()),
+            cwd: optional_path_to_string(conversation.cwd.as_ref()),
+            preview: conversation.preview.clone(),
+            summary: conversation.summary.clone(),
+            model: conversation.model.clone(),
+            message_count: conversation.message_count,
+            total_tokens: conversation.total_tokens,
+            duration_minutes: conversation.duration_minutes,
+            parse_errors: conversation.parse_errors.clone(),
+        }
+    }
+}
+
+fn messages_from_entries(entries: &[LogEntry]) -> Vec<MessageDto> {
+    let mut messages = Vec::new();
+    for entry in entries {
+        match entry {
+            LogEntry::Summary { summary } => {
+                let mut message = MessageDto::new("summary", None);
+                message.text = Some(summary.clone());
+                messages.push(message);
+            }
+            LogEntry::User {
+                message,
+                timestamp,
+                cwd: _,
+                ..
+            } => push_user_message(&mut messages, message, timestamp),
+            LogEntry::Assistant {
+                message, timestamp, ..
+            } => push_assistant_message(&mut messages, message, timestamp),
+            LogEntry::Progress { data, .. } => {
+                if let Some(progress) = parse_agent_progress(data) {
+                    let AgentContent::Blocks(blocks) = &progress.message.message.content;
+                    let role = format!("agent_{}", progress.message.message_type);
+                    for block in blocks {
+                        push_content_block(
+                            &mut messages,
+                            &role,
+                            None,
+                            None,
+                            Some(progress.agent_id.as_str()),
+                            block,
+                        );
+                    }
+                }
+            }
+            LogEntry::System {
+                subtype,
+                level,
+                duration_ms,
+                ..
+            } => {
+                let mut message = MessageDto::new("system", None);
+                message.subtype = Some(subtype.clone());
+                message.text = level.clone();
+                message.duration_ms = *duration_ms;
+                messages.push(message);
+            }
+            LogEntry::FileHistorySnapshot { .. } | LogEntry::Unknown => {}
+        }
+    }
+    messages
+}
+
+fn push_user_message(
+    messages: &mut Vec<MessageDto>,
+    message: &crate::claude::UserMessage,
+    timestamp: &str,
+) {
+    match &message.content {
+        UserContent::String(text) => {
+            push_text_message(messages, "user", Some(timestamp), None, None, text);
+        }
+        UserContent::Blocks(blocks) => {
+            for block in blocks {
+                push_content_block(messages, "user", Some(timestamp), None, None, block);
+            }
+        }
+    }
+}
+
+fn push_assistant_message(
+    messages: &mut Vec<MessageDto>,
+    message: &crate::claude::AssistantMessage,
+    timestamp: &str,
+) {
+    for block in &message.content {
+        push_content_block(
+            messages,
+            "assistant",
+            Some(timestamp),
+            message.model.as_deref(),
+            None,
+            block,
+        );
+    }
+}
+
+fn push_content_block(
+    messages: &mut Vec<MessageDto>,
+    text_role: &str,
+    timestamp: Option<&str>,
+    model: Option<&str>,
+    agent_id: Option<&str>,
+    block: &ContentBlock,
+) {
+    match block {
+        ContentBlock::Text { text } => {
+            push_text_message(messages, text_role, timestamp, model, agent_id, text);
+        }
+        ContentBlock::ToolUse { name, input, .. } => {
+            let mut message = MessageDto::new("tool_call", timestamp);
+            message.tool_name = Some(name.clone());
+            message.tool_input = Some(input.clone());
+            message.model = model.map(ToString::to_string);
+            message.agent_id = agent_id.map(ToString::to_string);
+            messages.push(message);
+        }
+        ContentBlock::ToolResult { content, .. } => {
+            let mut message = MessageDto::new("tool_result", timestamp);
+            message.text = tool_result_text(content.as_ref());
+            message.tool_result = content.clone();
+            message.agent_id = agent_id.map(ToString::to_string);
+            messages.push(message);
+        }
+        ContentBlock::Thinking { thinking, .. } => {
+            let mut message = MessageDto::new("thinking", timestamp);
+            message.thinking = Some(thinking.clone());
+            message.model = model.map(ToString::to_string);
+            message.agent_id = agent_id.map(ToString::to_string);
+            messages.push(message);
+        }
+        ContentBlock::Image { source } => {
+            let mut message = MessageDto::new("image", timestamp);
+            message.source = Some(source.clone());
+            message.agent_id = agent_id.map(ToString::to_string);
+            messages.push(message);
+        }
+    }
+}
+
+fn push_text_message(
+    messages: &mut Vec<MessageDto>,
+    role: &str,
+    timestamp: Option<&str>,
+    model: Option<&str>,
+    agent_id: Option<&str>,
+    text: &str,
+) {
+    if text.trim().is_empty() {
+        return;
+    }
+
+    let mut message = MessageDto::new(role, timestamp);
+    message.text = Some(text.to_string());
+    message.model = model.map(ToString::to_string);
+    message.agent_id = agent_id.map(ToString::to_string);
+    messages.push(message);
+}
+
+fn tool_result_text(content: Option<&Value>) -> Option<String> {
+    match content {
+        Some(Value::String(text)) => Some(text.clone()),
+        Some(Value::Array(items)) => {
+            let texts: Vec<_> = items
+                .iter()
+                .filter_map(|item| item.get("text").and_then(Value::as_str))
+                .collect();
+            (!texts.is_empty()).then(|| texts.join("\n\n"))
+        }
+        _ => None,
+    }
+}
+
+fn write_json<T: Serialize>(value: &T) -> Result<()> {
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    serde_json::to_writer_pretty(&mut handle, value)?;
+    writeln!(handle)?;
+    Ok(())
+}
+
+fn write_jsonl<T: Serialize>(values: &[T]) -> Result<()> {
+    let stdout = std::io::stdout();
+    let mut handle = stdout.lock();
+    for value in values {
+        serde_json::to_writer(&mut handle, value)?;
+        writeln!(handle)?;
+    }
+    Ok(())
+}
+
+fn provider_filter_matches(filter: Option<ProviderFilter>, kind: &ProviderKind) -> bool {
+    filter.is_none_or(|filter| match filter {
+        ProviderFilter::Claude => kind == &ProviderKind::Claude,
+        ProviderFilter::Codex => kind == &ProviderKind::Codex,
+        ProviderFilter::Cursor => kind == &ProviderKind::Cursor,
+        ProviderFilter::CursorAgent => kind == &ProviderKind::CursorAgent,
+    })
+}
+
+fn provider_key(kind: &ProviderKind) -> &'static str {
+    match kind {
+        ProviderKind::Claude => "claude",
+        ProviderKind::Codex => "codex",
+        ProviderKind::Cursor => "cursor",
+        ProviderKind::CursorAgent => "cursor-agent",
+    }
+}
+
+fn optional_path_to_string(path: Option<&PathBuf>) -> Option<String> {
+    path.map(|path| path.to_string_lossy().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::claude::{AssistantMessage, TokenUsage, UserMessage};
+    use chrono::{Local, TimeZone};
+
+    fn conversation(id: &str, path: &str, provider: ProviderKind) -> Conversation {
+        Conversation {
+            path: PathBuf::from(path),
+            index: 0,
+            provider,
+            id: id.to_string(),
+            timestamp: Local.timestamp_opt(1_700_000_000, 0).single().unwrap(),
+            preview: "preview".to_string(),
+            full_text: "full text".to_string(),
+            project_name: Some("project".to_string()),
+            project_path: Some(PathBuf::from("/tmp/project")),
+            cwd: Some(PathBuf::from("/tmp/project")),
+            message_count: 2,
+            parse_errors: Vec::new(),
+            summary: Some("summary".to_string()),
+            model: Some("model".to_string()),
+            total_tokens: 42,
+            duration_minutes: Some(3),
+            search_text_lower: None,
+            search_topic_end: None,
+        }
+    }
+
+    #[test]
+    fn summary_uses_stable_provider_key() {
+        let conversation = conversation("abc", "/tmp/abc.jsonl", ProviderKind::CursorAgent);
+        let summary = ConversationSummary::from_conversation(&conversation);
+        let json = serde_json::to_value(summary).unwrap();
+
+        assert_eq!(json["provider"], "cursor-agent");
+        assert_eq!(json["id"], "abc");
+        assert_eq!(json["path"], "/tmp/abc.jsonl");
+    }
+
+    #[test]
+    fn converts_entries_to_structured_messages() {
+        let entries = vec![
+            LogEntry::User {
+                message: UserMessage {
+                    role: "user".to_string(),
+                    content: UserContent::String("run tests".to_string()),
+                },
+                timestamp: "2026-06-19T10:00:00-07:00".to_string(),
+                uuid: None,
+                cwd: None,
+            },
+            LogEntry::Assistant {
+                message: AssistantMessage {
+                    role: "assistant".to_string(),
+                    content: vec![
+                        ContentBlock::Text {
+                            text: "I'll run them.".to_string(),
+                        },
+                        ContentBlock::ToolUse {
+                            id: "tool-1".to_string(),
+                            name: "Bash".to_string(),
+                            input: serde_json::json!({"cmd": "cargo test"}),
+                        },
+                        ContentBlock::Thinking {
+                            thinking: "Need to verify failures.".to_string(),
+                            signature: "sig".to_string(),
+                        },
+                    ],
+                    model: Some("claude-test".to_string()),
+                    usage: Some(TokenUsage::default()),
+                    id: None,
+                },
+                timestamp: "2026-06-19T10:00:01-07:00".to_string(),
+                uuid: None,
+            },
+        ];
+
+        let messages = messages_from_entries(&entries);
+
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0].role, "user");
+        assert_eq!(messages[1].role, "assistant");
+        assert_eq!(messages[2].role, "tool_call");
+        assert_eq!(messages[2].tool_name.as_deref(), Some("Bash"));
+        assert_eq!(messages[3].role, "thinking");
+        assert_eq!(messages[3].model.as_deref(), Some("claude-test"));
+    }
+
+    #[test]
+    fn resolves_unique_id() {
+        let conversations = vec![
+            conversation("abc", "/tmp/abc.jsonl", ProviderKind::Claude),
+            conversation("def", "/tmp/def.jsonl", ProviderKind::Codex),
+        ];
+
+        let resolved = resolve_conversation(&conversations, "def").unwrap();
+
+        assert_eq!(resolved.provider, ProviderKind::Codex);
+    }
+
+    #[test]
+    fn rejects_ambiguous_id() {
+        let conversations = vec![
+            conversation("same", "/tmp/a.jsonl", ProviderKind::Claude),
+            conversation("same", "/tmp/b.jsonl", ProviderKind::Codex),
+        ];
+
+        let err = match resolve_conversation(&conversations, "same") {
+            Ok(_) => panic!("expected ambiguous conversation error"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("Ambiguous conversation target"));
+    }
+}

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -62,6 +62,8 @@ struct MessageDto {
     #[serde(skip_serializing_if = "Option::is_none")]
     subtype: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    level: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     duration_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     source: Option<Value>,
@@ -80,6 +82,7 @@ impl MessageDto {
             model: None,
             agent_id: None,
             subtype: None,
+            level: None,
             duration_ms: None,
             source: None,
         }
@@ -144,7 +147,7 @@ fn run_show(
         .ok_or_else(|| {
             AppError::CommandError(format!(
                 "No provider found for {} conversation",
-                provider_key(&conversation.provider)
+                conversation.provider.key()
             ))
         })?;
     let entries = provider.read_entries(conversation)?;
@@ -298,7 +301,7 @@ fn resolve_conversation<'a>(
                 .map(|conversation| {
                     format!(
                         "{}:{} ({})",
-                        provider_key(&conversation.provider),
+                        conversation.provider.key(),
                         conversation.id,
                         conversation.path.display()
                     )
@@ -306,7 +309,8 @@ fn resolve_conversation<'a>(
                 .collect::<Vec<_>>()
                 .join(", ");
             Err(AppError::CommandError(format!(
-                "Ambiguous conversation target '{}'; matches: {}",
+                "Ambiguous conversation target '{}'; matches: {}. \
+                 Pass --provider <name> to disambiguate.",
                 target, rendered
             )))
         }
@@ -325,7 +329,7 @@ fn path_matches(path: &Path, target: &Path, target_canonical: Option<&Path>) -> 
 impl ConversationSummary {
     fn from_conversation(conversation: &Conversation) -> Self {
         Self {
-            provider: provider_key(&conversation.provider),
+            provider: conversation.provider.key(),
             id: conversation.id.clone(),
             path: conversation.path.to_string_lossy().to_string(),
             timestamp: conversation.timestamp.to_rfc3339(),
@@ -385,7 +389,9 @@ fn messages_from_entries(entries: &[LogEntry]) -> Vec<MessageDto> {
             } => {
                 let mut message = MessageDto::new("system", None);
                 message.subtype = Some(subtype.clone());
-                message.text = level.clone();
+                // `level` is a log severity ("info"/"warning"/...), not chat
+                // content, so keep it out of the `text` field consumers read.
+                message.level = level.clone();
                 message.duration_ms = *duration_ms;
                 messages.push(message);
             }
@@ -505,40 +511,46 @@ fn tool_result_text(content: Option<&Value>) -> Option<String> {
     }
 }
 
+fn json_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>> {
+    let mut buf = serde_json::to_vec_pretty(value)?;
+    buf.push(b'\n');
+    Ok(buf)
+}
+
+/// Serialize each value as a compact JSON object on its own line (JSONL).
+fn jsonl_bytes<T: Serialize>(values: &[T]) -> Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    for value in values {
+        serde_json::to_writer(&mut buf, value)?;
+        buf.push(b'\n');
+    }
+    Ok(buf)
+}
+
 fn write_json<T: Serialize>(value: &T) -> Result<()> {
-    let stdout = std::io::stdout();
-    let mut handle = stdout.lock();
-    serde_json::to_writer_pretty(&mut handle, value)?;
-    writeln!(handle)?;
-    Ok(())
+    write_stdout(&json_bytes(value)?)
 }
 
 fn write_jsonl<T: Serialize>(values: &[T]) -> Result<()> {
+    write_stdout(&jsonl_bytes(values)?)
+}
+
+/// Write a fully-serialized buffer to stdout in a single call.
+///
+/// Serializing into memory first means a closed downstream pipe (e.g.
+/// `mnemonai list | head`) surfaces as a plain `io::ErrorKind::BrokenPipe` from
+/// this one `write_all` rather than a misleading "JSON parsing error", letting
+/// `main` exit cleanly.
+fn write_stdout(buf: &[u8]) -> Result<()> {
     let stdout = std::io::stdout();
     let mut handle = stdout.lock();
-    for value in values {
-        serde_json::to_writer(&mut handle, value)?;
-        writeln!(handle)?;
-    }
+    handle.write_all(buf)?;
+    handle.flush()?;
     Ok(())
 }
 
 fn provider_filter_matches(filter: Option<ProviderFilter>, kind: &ProviderKind) -> bool {
-    filter.is_none_or(|filter| match filter {
-        ProviderFilter::Claude => kind == &ProviderKind::Claude,
-        ProviderFilter::Codex => kind == &ProviderKind::Codex,
-        ProviderFilter::Cursor => kind == &ProviderKind::Cursor,
-        ProviderFilter::CursorAgent => kind == &ProviderKind::CursorAgent,
-    })
-}
-
-fn provider_key(kind: &ProviderKind) -> &'static str {
-    match kind {
-        ProviderKind::Claude => "claude",
-        ProviderKind::Codex => "codex",
-        ProviderKind::Cursor => "cursor",
-        ProviderKind::CursorAgent => "cursor-agent",
-    }
+    filter.is_none_or(|filter| &filter.kind() == kind)
 }
 
 fn optional_path_to_string(path: Option<&PathBuf>) -> Option<String> {
@@ -659,5 +671,197 @@ mod tests {
         };
 
         assert!(err.to_string().contains("Ambiguous conversation target"));
+    }
+
+    #[test]
+    fn ambiguity_error_suggests_provider() {
+        let conversations = vec![
+            conversation("same", "/tmp/a.jsonl", ProviderKind::Claude),
+            conversation("same", "/tmp/b.jsonl", ProviderKind::Codex),
+        ];
+
+        let err = match resolve_conversation(&conversations, "same") {
+            Ok(_) => panic!("expected ambiguous conversation error"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("--provider"));
+    }
+
+    #[test]
+    fn resolves_by_path_and_file_stem() {
+        let conversations = vec![
+            conversation("id-a", "/tmp/sess-a.jsonl", ProviderKind::Claude),
+            conversation("id-b", "/tmp/sess-b.jsonl", ProviderKind::Codex),
+        ];
+
+        let by_path = resolve_conversation(&conversations, "/tmp/sess-b.jsonl").unwrap();
+        assert_eq!(by_path.id, "id-b");
+
+        let by_stem = resolve_conversation(&conversations, "sess-a").unwrap();
+        assert_eq!(by_stem.id, "id-a");
+    }
+
+    #[test]
+    fn rejects_unknown_target() {
+        let conversations = vec![conversation(
+            "id-a",
+            "/tmp/sess-a.jsonl",
+            ProviderKind::Claude,
+        )];
+
+        let err = match resolve_conversation(&conversations, "does-not-exist") {
+            Ok(_) => panic!("expected no-conversation error"),
+            Err(err) => err,
+        };
+
+        assert!(err.to_string().contains("No conversation found"));
+    }
+
+    #[test]
+    fn normalizes_system_image_tool_result_and_summary_entries() {
+        let entries = vec![
+            LogEntry::Summary {
+                summary: "Session title".to_string(),
+            },
+            // Blank user text is dropped rather than emitted as an empty message.
+            LogEntry::User {
+                message: UserMessage {
+                    role: "user".to_string(),
+                    content: UserContent::String("   ".to_string()),
+                },
+                timestamp: "2026-06-19T10:00:00-07:00".to_string(),
+                uuid: None,
+                cwd: None,
+            },
+            LogEntry::Assistant {
+                message: AssistantMessage {
+                    role: "assistant".to_string(),
+                    content: vec![
+                        ContentBlock::ToolResult {
+                            tool_use_id: "t1".to_string(),
+                            content: Some(serde_json::json!([
+                                {"type": "text", "text": "line one"},
+                                {"type": "text", "text": "line two"},
+                            ])),
+                        },
+                        ContentBlock::Image {
+                            source: serde_json::json!({"type": "base64", "media_type": "image/png"}),
+                        },
+                    ],
+                    model: Some("claude-test".to_string()),
+                    usage: None,
+                    id: None,
+                },
+                timestamp: "2026-06-19T10:00:01-07:00".to_string(),
+                uuid: None,
+            },
+            LogEntry::System {
+                subtype: "turn_duration".to_string(),
+                level: Some("warning".to_string()),
+                duration_ms: Some(1234),
+                parent_uuid: None,
+                extra: serde_json::Value::Null,
+            },
+        ];
+
+        let messages = messages_from_entries(&entries);
+
+        let roles: Vec<_> = messages.iter().map(|m| m.role.as_str()).collect();
+        assert_eq!(roles, vec!["summary", "tool_result", "image", "system"]);
+
+        assert_eq!(messages[0].text.as_deref(), Some("Session title"));
+
+        assert_eq!(messages[1].text.as_deref(), Some("line one\n\nline two"));
+        assert!(messages[1].tool_result.is_some());
+
+        assert!(messages[2].source.is_some());
+
+        let system = &messages[3];
+        assert_eq!(system.subtype.as_deref(), Some("turn_duration"));
+        assert_eq!(system.level.as_deref(), Some("warning"));
+        assert_eq!(system.duration_ms, Some(1234));
+        assert!(
+            system.text.is_none(),
+            "system log level must not leak into the text field"
+        );
+    }
+
+    #[test]
+    fn jsonl_bytes_emit_one_compact_object_per_line() {
+        let summaries = vec![
+            ConversationSummary::from_conversation(&conversation(
+                "a",
+                "/tmp/a.jsonl",
+                ProviderKind::Claude,
+            )),
+            ConversationSummary::from_conversation(&conversation(
+                "b",
+                "/tmp/b.jsonl",
+                ProviderKind::Codex,
+            )),
+        ];
+
+        let text = String::from_utf8(jsonl_bytes(&summaries).unwrap()).unwrap();
+        let lines: Vec<_> = text.lines().collect();
+
+        assert_eq!(lines.len(), 2);
+        assert!(
+            !text.trim_start().starts_with('['),
+            "JSONL must not be an array"
+        );
+        let first: Value = serde_json::from_str(lines[0]).unwrap();
+        let second: Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(first["id"], "a");
+        assert_eq!(second["id"], "b");
+    }
+
+    #[test]
+    fn provider_filter_matches_expected_kinds() {
+        assert!(provider_filter_matches(None, &ProviderKind::Cursor));
+        assert!(provider_filter_matches(
+            Some(ProviderFilter::Codex),
+            &ProviderKind::Codex
+        ));
+        assert!(!provider_filter_matches(
+            Some(ProviderFilter::Codex),
+            &ProviderKind::Claude
+        ));
+        assert!(provider_filter_matches(
+            Some(ProviderFilter::CursorAgent),
+            &ProviderKind::CursorAgent
+        ));
+    }
+
+    #[test]
+    fn show_reads_and_normalizes_a_claude_jsonl_file() {
+        use crate::providers::Provider;
+        use crate::providers::claude::ClaudeProvider;
+
+        let path = std::env::temp_dir().join(format!(
+            "mnemonai-headless-show-{}.jsonl",
+            std::process::id()
+        ));
+        let contents = concat!(
+            r#"{"type":"user","message":{"role":"user","content":"hello there"},"timestamp":"2026-06-19T10:00:00-07:00"}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hi back"}],"model":"claude-test"},"timestamp":"2026-06-19T10:00:01-07:00"}"#,
+            "\n",
+        );
+        std::fs::write(&path, contents).unwrap();
+
+        let conversation = conversation("rt-id", path.to_str().unwrap(), ProviderKind::Claude);
+        let provider = ClaudeProvider::new(vec![]);
+        let entries = provider.read_entries(&conversation).unwrap();
+        let messages = messages_from_entries(&entries);
+
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, "user");
+        assert_eq!(messages[0].text.as_deref(), Some("hello there"));
+        assert_eq!(messages[1].role, "assistant");
+        assert_eq!(messages[1].text.as_deref(), Some("hi back"));
+        assert_eq!(messages[1].model.as_deref(), Some("claude-test"));
     }
 }

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -335,6 +335,10 @@ pub fn load_conversations(
     Ok(conversations)
 }
 
+/// Conversations loaded from one project, paired with the freshly parsed
+/// (cache-miss) ones the caller should persist in a single batch.
+type ProjectLoad = (Vec<Conversation>, Vec<(Conversation, SourceFingerprint)>);
+
 /// Load one project directory. Returns the conversations plus clones of the
 /// freshly parsed ones (cache misses) so the caller can persist them in a
 /// single batch — per-project writes would race for the SQLite write lock.
@@ -343,7 +347,7 @@ fn load_conversations_with_cache(
     show_last: bool,
     debug_level: Option<DebugLevel>,
     cache: &Mutex<HashMap<PathBuf, CachedFileConversation>>,
-) -> Result<(Vec<Conversation>, Vec<(Conversation, SourceFingerprint)>)> {
+) -> Result<ProjectLoad> {
     // Find all JSONL files and capture metadata in one pass
     let mut files_with_meta = Vec::new();
     let mut skipped_agent_files = 0;

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -25,8 +25,8 @@ use std::time::SystemTime;
 pub use loader::{load_all_conversations_streaming, load_conversations};
 pub use parser::process_conversation_file;
 pub use path::{
-    convert_path_to_project_dir_name, format_short_name_from_path, project_path_is_live,
-    resolve_project_dir,
+    convert_path_to_project_dir_name, format_short_name_from_path, path_to_string,
+    project_path_is_live, resolve_project_dir,
 };
 
 /// Identifies which AI tool provider a conversation originated from

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -38,6 +38,19 @@ pub enum ProviderKind {
     CursorAgent,
 }
 
+impl ProviderKind {
+    /// Stable lowercase key used in the cache schema and the headless JSON
+    /// output. Keep these strings stable; consumers depend on them.
+    pub fn key(&self) -> &'static str {
+        match self {
+            ProviderKind::Claude => "claude",
+            ProviderKind::Codex => "codex",
+            ProviderKind::Cursor => "cursor",
+            ProviderKind::CursorAgent => "cursor-agent",
+        }
+    }
+}
+
 /// Represents a JSONL parsing error with context for debugging
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ParseError {

--- a/src/history/path.rs
+++ b/src/history/path.rs
@@ -33,10 +33,10 @@ pub fn convert_path_to_project_dir_name(path: &Path) -> String {
 /// For regular paths, returns just the folder name.
 pub fn format_short_name_from_path(path: &Path) -> String {
     // If the path is the user's home directory, display as ~
-    if let Some(home) = home::home_dir() {
-        if path == home {
-            return "~".to_string();
-        }
+    if let Some(home) = home::home_dir()
+        && path == home
+    {
+        return "~".to_string();
     }
 
     let path_str = path.to_string_lossy();

--- a/src/history/path.rs
+++ b/src/history/path.rs
@@ -6,6 +6,11 @@
 
 use std::path::{Path, PathBuf};
 
+/// Lossily render an optional path as an optional string.
+pub fn path_to_string(path: Option<&Path>) -> Option<String> {
+    path.map(|path| path.to_string_lossy().to_string())
+}
+
 /// Convert the current working directory into Claude's project directory name.
 pub fn convert_path_to_project_dir_name(path: &Path) -> String {
     path.to_string_lossy()

--- a/src/history/path.rs
+++ b/src/history/path.rs
@@ -247,10 +247,7 @@ mod tests {
     fn converts_various_separators_and_punctuation() {
         let path = Path::new("/Users/user/code/workmux/.worktrees/uncommitted");
         let converted = convert_path_to_project_dir_name(path);
-        assert_eq!(
-            converted,
-            "-Users-user-code-workmux--worktrees-uncommitted"
-        );
+        assert_eq!(converted, "-Users-user-code-workmux--worktrees-uncommitted");
     }
 
     #[test]

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,0 +1,77 @@
+//! Shared conversation-loading helpers used by both the interactive TUI and the
+//! headless commands so they apply identical local and provider filtering.
+
+use crate::cli::{DebugLevel, ProviderFilter};
+use crate::error::{AppError, Result};
+use crate::history::{Conversation, ProviderKind};
+use crate::providers::Provider;
+
+/// Whether a provider should be included given an optional provider filter.
+/// `None` matches every provider.
+pub fn provider_filter_matches(filter: Option<ProviderFilter>, kind: &ProviderKind) -> bool {
+    filter.is_none_or(|filter| &filter.kind() == kind)
+}
+
+/// Load conversations scoped to the current directory across all providers.
+///
+/// Mirrors the TUI's local-mode loading: non-Claude providers are filtered to
+/// the current directory, while Claude's loader is already directory-scoped.
+/// Providers that fail to load are silently skipped. The result is unsorted and
+/// unindexed; callers sort by timestamp and assign display indexes.
+pub fn load_local(
+    providers: &[Box<dyn Provider>],
+    show_last: bool,
+    debug: Option<DebugLevel>,
+    provider_filter: Option<ProviderFilter>,
+) -> Result<Vec<Conversation>> {
+    let current_dir = std::env::current_dir().map_err(|err| {
+        AppError::Io(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("Failed to get current directory: {}", err),
+        ))
+    })?;
+
+    let mut conversations = Vec::new();
+    for provider in providers {
+        if !provider_filter_matches(provider_filter, &provider.kind()) {
+            continue;
+        }
+
+        if let Ok(mut provider_conversations) = provider.load_conversations(show_last, debug) {
+            // For non-Claude providers, filter to the current directory.
+            if provider.kind() != ProviderKind::Claude {
+                provider_conversations.retain(|conversation| {
+                    conversation
+                        .project_path
+                        .as_ref()
+                        .is_some_and(|path| path == &current_dir)
+                });
+            }
+            conversations.extend(provider_conversations);
+        }
+    }
+
+    Ok(conversations)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_filter_matches_expected_kinds() {
+        assert!(provider_filter_matches(None, &ProviderKind::Cursor));
+        assert!(provider_filter_matches(
+            Some(ProviderFilter::Codex),
+            &ProviderKind::Codex
+        ));
+        assert!(!provider_filter_matches(
+            Some(ProviderFilter::Codex),
+            &ProviderKind::Claude
+        ));
+        assert!(provider_filter_matches(
+            Some(ProviderFilter::CursorAgent),
+            &ProviderKind::CursorAgent
+        ));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod display;
 mod error;
 mod headless;
 mod history;
+mod loader;
 mod markdown;
 mod pager;
 mod providers;
@@ -231,28 +232,7 @@ fn run() -> Result<()> {
         }
     } else {
         // Local mode - load from all providers for current directory
-        let current_dir = std::env::current_dir().map_err(|e| {
-            AppError::Io(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("Failed to get current directory: {}", e),
-            ))
-        })?;
-
-        let mut conversations = Vec::new();
-
-        for provider in &providers {
-            match provider.load_conversations(show_last, args.debug) {
-                Ok(mut convs) => {
-                    // For non-Claude providers, filter to current directory
-                    if provider.kind() != history::ProviderKind::Claude {
-                        convs
-                            .retain(|c| c.project_path.as_ref().is_some_and(|p| p == &current_dir));
-                    }
-                    conversations.extend(convs);
-                }
-                Err(_) => {} // Silently skip providers that fail in local mode
-            }
-        }
+        let mut conversations = loader::load_local(&providers, show_last, args.debug, None)?;
 
         // Sort merged conversations by timestamp (newest first) and re-index
         conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,10 +197,10 @@ fn run() -> Result<()> {
 
     // Handle --show-dir flag (Claude-specific, print directory and exit)
     if args.show_dir {
-        if let Ok(current_dir) = std::env::current_dir() {
-            if let Ok(projects_dir) = history::get_claude_projects_dir(&current_dir) {
-                println!("{}", projects_dir.display());
-            }
+        if let Ok(current_dir) = std::env::current_dir()
+            && let Ok(projects_dir) = history::get_claude_projects_dir(&current_dir)
+        {
+            println!("{}", projects_dir.display());
         }
         return Ok(());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,11 @@ fn main() {
                 // User cancelled, exit silently
                 std::process::exit(0);
             }
+            // A consumer closing the pipe early (e.g. `mnemonai list | head`) is
+            // normal; exit quietly instead of printing a misleading error.
+            AppError::Io(ref io_err) if io_err.kind() == std::io::ErrorKind::BrokenPipe => {
+                std::process::exit(0);
+            }
             _ => {
                 eprintln!("Error: {}", e);
                 std::process::exit(1);
@@ -154,9 +159,23 @@ fn run() -> Result<()> {
     // Handle direct file input mode
     if let Some(ref input_file) = args.input_file {
         if !input_file.exists() {
+            // A bare word with no path separator or extension (e.g. `dump`,
+            // `search`, or a misspelled `list`) was likely meant as a
+            // subcommand, which clap routed to the legacy file positional.
+            let looks_like_subcommand = input_file
+                .to_str()
+                .is_some_and(|name| !name.contains(['/', '\\', '.']));
+            let message = if looks_like_subcommand {
+                format!(
+                    "File not found: {} (if you meant a subcommand, see `mnemonai --help`)",
+                    input_file.display()
+                )
+            } else {
+                format!("File not found: {}", input_file.display())
+            };
             return Err(AppError::Io(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
-                format!("File not found: {}", input_file.display()),
+                message,
             )));
         }
         if !input_file.is_file() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod debug;
 mod debug_log;
 mod display;
 mod error;
+mod headless;
 mod history;
 mod markdown;
 mod pager;
@@ -121,6 +122,17 @@ fn run() -> Result<()> {
         Box::new(providers::cursor_agent::CursorAgentProvider::new()),
         Box::new(providers::cursor::CursorProvider::new()),
     ];
+
+    if let Some(ref command) = args.command {
+        let settings = headless::HeadlessSettings {
+            cli_local: args.local,
+            config_local: config.local.unwrap_or(false),
+            show_last,
+            show_deleted_projects,
+            debug: args.debug,
+        };
+        return headless::run_command(command, &providers, &settings);
+    }
 
     // Handle --bench-startup flag: time the streaming load headlessly and exit
     if args.bench_startup {
@@ -360,15 +372,19 @@ fn bench_startup(
                     }
                 }
                 let done_ms = overall.elapsed().as_millis();
-                (name, first_batch_ms, done_ms, conversations, batches, errors)
+                (
+                    name,
+                    first_batch_ms,
+                    done_ms,
+                    conversations,
+                    batches,
+                    errors,
+                )
             })
         })
         .collect();
 
-    let mut results: Vec<_> = handles
-        .into_iter()
-        .filter_map(|h| h.join().ok())
-        .collect();
+    let mut results: Vec<_> = handles.into_iter().filter_map(|h| h.join().ok()).collect();
     results.sort_by_key(|r| r.2);
 
     let total_ms = overall.elapsed().as_millis();

--- a/src/providers/cursor.rs
+++ b/src/providers/cursor.rs
@@ -274,13 +274,13 @@ fn query_user_bubble_keys(conn: &Connection, show_last: bool) -> HashMap<String,
         order_func
     );
     let mut user_keys = HashMap::new();
-    if let Ok(mut stmt) = conn.prepare(&user_query) {
-        if let Ok(rows) = stmt.query_map([], |row| {
+    if let Ok(mut stmt) = conn.prepare(&user_query)
+        && let Ok(rows) = stmt.query_map([], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        }) {
-            for row in rows.flatten() {
-                user_keys.insert(row.0, row.1);
-            }
+        })
+    {
+        for row in rows.flatten() {
+            user_keys.insert(row.0, row.1);
         }
     }
     user_keys
@@ -497,9 +497,7 @@ fn build_full_text_map(
     conv_infos: &[ConvInfo],
     cache_conn: Option<&Connection>,
 ) -> HashMap<String, String> {
-    let cached = cache_conn
-        .map(|c| load_cached_full_text(c))
-        .unwrap_or_default();
+    let cached = cache_conn.map(load_cached_full_text).unwrap_or_default();
     build_full_text_map_from_cached(None, cursor_conn, conv_infos, &cached, cache_conn)
 }
 
@@ -648,11 +646,10 @@ fn load_index_timestamps(conn: &Connection) -> HashMap<String, i64> {
         "SELECT value FROM ItemTable WHERE key = 'conversationClassificationScoredConversations'",
         [],
         |row| row.get(0),
-    ) {
-        if let Ok(index) = serde_json::from_str::<Vec<ConversationIndexEntry>>(&json) {
-            for entry in index {
-                timestamps.insert(entry.conversation_id, entry.timestamp);
-            }
+    ) && let Ok(index) = serde_json::from_str::<Vec<ConversationIndexEntry>>(&json)
+    {
+        for entry in index {
+            timestamps.insert(entry.conversation_id, entry.timestamp);
         }
     }
     timestamps
@@ -1063,12 +1060,11 @@ impl super::Provider for CursorProvider {
                     .collect();
 
                 let mut full_map = bubble_map;
-                if !extra_keys.is_empty() {
-                    if let Ok(extra) =
+                if !extra_keys.is_empty()
+                    && let Ok(extra) =
                         batch_fetch_bubbles_parallel(&global_db_path, &conn, &extra_keys)
-                    {
-                        full_map.extend(extra);
-                    }
+                {
+                    full_map.extend(extra);
                 }
 
                 let phase2_convs: Vec<Conversation> = remaining_infos
@@ -1117,7 +1113,7 @@ impl super::Provider for CursorProvider {
         // Uses cwd which stores the open_path (may be a .code-workspace file)
         if let Some(ref path) = conversation.cwd {
             Command::new("cursor")
-                .arg(&path.to_string_lossy().as_ref())
+                .arg(path.to_string_lossy().as_ref())
                 .spawn()
                 .map_err(|e| {
                     AppError::ClaudeExecutionError(format!("Failed to launch Cursor: {}", e))
@@ -1173,22 +1169,17 @@ impl super::Provider for CursorProvider {
             "SELECT value FROM ItemTable WHERE key = 'conversationClassificationScoredConversations'",
             [],
             |row| row.get(0),
-        ) {
-            if let Ok(mut index) = serde_json::from_str::<Vec<Value>>(&index_json) {
-                let before = index.len();
-                index.retain(|e| {
-                    e.get("conversationId")
-                        .and_then(|v| v.as_str())
-                        != Some(conv_id)
-                });
-                if index.len() != before {
-                    if let Ok(new_json) = serde_json::to_string(&index) {
-                        let _ = conn.execute(
-                            "UPDATE ItemTable SET value = ? WHERE key = 'conversationClassificationScoredConversations'",
-                            rusqlite::params![&new_json],
-                        );
-                    }
-                }
+        ) && let Ok(mut index) = serde_json::from_str::<Vec<Value>>(&index_json)
+        {
+            let before = index.len();
+            index.retain(|e| e.get("conversationId").and_then(|v| v.as_str()) != Some(conv_id));
+            if index.len() != before
+                && let Ok(new_json) = serde_json::to_string(&index)
+            {
+                let _ = conn.execute(
+                    "UPDATE ItemTable SET value = ? WHERE key = 'conversationClassificationScoredConversations'",
+                    rusqlite::params![&new_json],
+                );
             }
         }
 
@@ -1406,10 +1397,10 @@ fn bubble_text(bubble: &Bubble) -> String {
         return bubble.text.clone();
     }
     // Fallback to richText for user messages
-    if let Some(ref rt) = bubble.rich_text {
-        if let Some(text) = extract_text_from_richtext(rt) {
-            return text;
-        }
+    if let Some(ref rt) = bubble.rich_text
+        && let Some(text) = extract_text_from_richtext(rt)
+    {
+        return text;
     }
     String::new()
 }

--- a/src/providers/cursor_agent.rs
+++ b/src/providers/cursor_agent.rs
@@ -437,12 +437,12 @@ impl super::Provider for CursorAgentProvider {
     }
 
     fn delete(&self, conversation: &Conversation) -> Result<()> {
-        if let Some(transcript_dir) = transcript_parent_dir(&conversation.path, &conversation.id) {
-            if transcript_dir.exists() {
-                fs::remove_dir_all(transcript_dir)?;
-                delete_conversation(ProviderKind::CursorAgent, &conversation.path);
-                return Ok(());
-            }
+        if let Some(transcript_dir) = transcript_parent_dir(&conversation.path, &conversation.id)
+            && transcript_dir.exists()
+        {
+            fs::remove_dir_all(transcript_dir)?;
+            delete_conversation(ProviderKind::CursorAgent, &conversation.path);
+            return Ok(());
         }
 
         fs::remove_file(&conversation.path)?;
@@ -816,7 +816,7 @@ fn resolve_workspace_path(encoded_dir_name: &str, chats_dir: Option<&Path>) -> O
                 }
             }
             // Fall back to the longest path (most specific)
-            candidates.sort_by(|a, b| b.len().cmp(&a.len()));
+            candidates.sort_by_key(|b| std::cmp::Reverse(b.len()));
             Some(PathBuf::from(candidates.into_iter().next().unwrap()))
         }
     }

--- a/src/providers/cursor_agent.rs
+++ b/src/providers/cursor_agent.rs
@@ -413,12 +413,13 @@ impl super::Provider for CursorAgentProvider {
         {
             path.clone()
         } else {
-            let encoded_dir_name = extract_project_dir_name(&conversation.path).ok_or_else(|| {
-                AppError::ClaudeExecutionError(
-                    "Cannot determine project directory for this Cursor Agent conversation"
-                        .to_string(),
-                )
-            })?;
+            let encoded_dir_name =
+                extract_project_dir_name(&conversation.path).ok_or_else(|| {
+                    AppError::ClaudeExecutionError(
+                        "Cannot determine project directory for this Cursor Agent conversation"
+                            .to_string(),
+                    )
+                })?;
             let chats_dir = self
                 .projects_root
                 .parent()
@@ -913,13 +914,11 @@ fn component_prefix_viable(prefix: &str, is_last: bool) -> bool {
     // Exclude exact matches: if the only entry is the prefix itself, there's no
     // longer name to continue building. Exact-match directories are already
     // handled by the `path.is_dir()` check above.
-    entries
-        .filter_map(|e| e.ok())
-        .any(|e| {
-            e.file_name()
-                .to_str()
-                .is_some_and(|name| name.starts_with(name_prefix) && name != name_prefix)
-        })
+    entries.filter_map(|e| e.ok()).any(|e| {
+        e.file_name()
+            .to_str()
+            .is_some_and(|name| name.starts_with(name_prefix) && name != name_prefix)
+    })
 }
 
 fn file_modified_time(path: &Path) -> Option<SystemTime> {
@@ -1079,8 +1078,7 @@ mod tests {
 
     #[test]
     fn parse_transcript_line_rejects_message_like_records_with_type_but_no_role() {
-        let line =
-            r#"{"type":"future_message","message":{"content":[{"type":"text","text":"missing role"}]}}"#;
+        let line = r#"{"type":"future_message","message":{"content":[{"type":"text","text":"missing role"}]}}"#;
 
         assert!(parse_transcript_line(line, 1, None).is_err());
     }
@@ -1205,8 +1203,12 @@ mod tests {
                 .duration_since(UNIX_EPOCH)
                 .unwrap()
                 .as_nanos();
-            let path =
-                PathBuf::from("/tmp").join(format!("mnemonai-{}-{}-{}", name, std::process::id(), unique));
+            let path = PathBuf::from("/tmp").join(format!(
+                "mnemonai-{}-{}-{}",
+                name,
+                std::process::id(),
+                unique
+            ));
             fs::create_dir_all(&path).unwrap();
             Self { path }
         }
@@ -1305,7 +1307,10 @@ mod tests {
 
         // Create a fake chats dir with the MD5 of candidate_b
         let chats_dir = temp.path.join("chats");
-        let hash_b = format!("{:x}", md5::compute(candidate_b.to_string_lossy().as_bytes()));
+        let hash_b = format!(
+            "{:x}",
+            md5::compute(candidate_b.to_string_lossy().as_bytes())
+        );
         fs::create_dir_all(chats_dir.join(&hash_b)).unwrap();
 
         let parent_name = temp.path.file_name().unwrap().to_str().unwrap();

--- a/src/tui/export.rs
+++ b/src/tui/export.rs
@@ -136,7 +136,11 @@ fn generate_content(
     }
 }
 
-/// Read log entries from a JSONL file for export
+/// Read log entries from a JSONL file for export.
+///
+/// Unreadable lines are skipped rather than aborting the read, so a single
+/// corrupt line doesn't truncate an otherwise-parseable transcript.
+#[allow(clippy::lines_filter_map_ok)]
 fn read_entries_from_file(path: &Path) -> std::io::Result<Vec<LogEntry>> {
     let file = File::open(path)?;
     let reader = BufReader::new(file);
@@ -175,13 +179,13 @@ fn generate_plain_from_entries(entries: &[LogEntry], options: ExportOptions) -> 
                 if let Some(text) = extract_user_text(message) {
                     output.push_str(&format!("You: {}\n\n", text));
                 }
-                if options.show_tools {
-                    if let UserContent::Blocks(blocks) = &message.content {
-                        for block in blocks {
-                            if let ContentBlock::ToolResult { content, .. } = block {
-                                let content_str = format_tool_result_for_export(content.as_ref());
-                                output.push_str(&format!("Tool Result: {}\n\n", content_str));
-                            }
+                if options.show_tools
+                    && let UserContent::Blocks(blocks) = &message.content
+                {
+                    for block in blocks {
+                        if let ContentBlock::ToolResult { content, .. } = block {
+                            let content_str = format_tool_result_for_export(content.as_ref());
+                            output.push_str(&format!("Tool Result: {}\n\n", content_str));
                         }
                     }
                 }
@@ -220,14 +224,14 @@ fn generate_markdown_from_entries(entries: &[LogEntry], options: ExportOptions) 
                 if let Some(text) = extract_user_text(message) {
                     output.push_str(&format!("## You\n\n{}\n\n", text));
                 }
-                if options.show_tools {
-                    if let UserContent::Blocks(blocks) = &message.content {
-                        for block in blocks {
-                            if let ContentBlock::ToolResult { content, .. } = block {
-                                let content_str = format_tool_result_for_export(content.as_ref());
-                                let fenced = markdown_code_fence(&content_str);
-                                output.push_str(&format!("### Tool Result\n\n{}\n\n", fenced));
-                            }
+                if options.show_tools
+                    && let UserContent::Blocks(blocks) = &message.content
+                {
+                    for block in blocks {
+                        if let ContentBlock::ToolResult { content, .. } = block {
+                            let content_str = format_tool_result_for_export(content.as_ref());
+                            let fenced = markdown_code_fence(&content_str);
+                            output.push_str(&format!("### Tool Result\n\n{}\n\n", fenced));
                         }
                     }
                 }
@@ -272,19 +276,14 @@ fn generate_ledger_from_entries(entries: &[LogEntry], options: ExportOptions) ->
                     append_ledger_block(&mut output, "You", &text, NAME_WIDTH);
                     output.push('\n');
                 }
-                if options.show_tools {
-                    if let UserContent::Blocks(blocks) = &message.content {
-                        for block in blocks {
-                            if let ContentBlock::ToolResult { content, .. } = block {
-                                let content_str = format_tool_result_for_export(content.as_ref());
-                                append_ledger_block(
-                                    &mut output,
-                                    "↳ Result",
-                                    &content_str,
-                                    NAME_WIDTH,
-                                );
-                                output.push('\n');
-                            }
+                if options.show_tools
+                    && let UserContent::Blocks(blocks) = &message.content
+                {
+                    for block in blocks {
+                        if let ContentBlock::ToolResult { content, .. } = block {
+                            let content_str = format_tool_result_for_export(content.as_ref());
+                            append_ledger_block(&mut output, "↳ Result", &content_str, NAME_WIDTH);
+                            output.push('\n');
                         }
                     }
                 }

--- a/src/tui/export.rs
+++ b/src/tui/export.rs
@@ -236,7 +236,10 @@ fn generate_markdown_from_entries(entries: &[LogEntry], options: ExportOptions) 
                 for block in &message.content {
                     match block {
                         ContentBlock::Text { text } => {
-                            output.push_str(&format!("## {}\n\n{}\n\n", options.assistant_label, text));
+                            output.push_str(&format!(
+                                "## {}\n\n{}\n\n",
+                                options.assistant_label, text
+                            ));
                         }
                         ContentBlock::ToolUse { name, input, .. } if options.show_tools => {
                             let formatted = format_tool_call_for_export(name, input);
@@ -290,7 +293,12 @@ fn generate_ledger_from_entries(entries: &[LogEntry], options: ExportOptions) ->
                 for block in &message.content {
                     match block {
                         ContentBlock::Text { text } => {
-                            append_ledger_block(&mut output, &options.assistant_label, text, NAME_WIDTH);
+                            append_ledger_block(
+                                &mut output,
+                                &options.assistant_label,
+                                text,
+                                NAME_WIDTH,
+                            );
                             output.push('\n');
                         }
                         ContentBlock::ToolUse { name, input, .. } if options.show_tools => {

--- a/src/tui/viewer.rs
+++ b/src/tui/viewer.rs
@@ -94,7 +94,11 @@ fn format_timestamp(iso_timestamp: &str) -> Option<String> {
         .map(|dt| dt.with_timezone(&Local).format("%H:%M").to_string())
 }
 
-/// Read log entries from a JSONL file
+/// Read log entries from a JSONL file.
+///
+/// Unreadable lines are skipped rather than aborting the read, so a single
+/// corrupt line doesn't truncate an otherwise-parseable transcript.
+#[allow(clippy::lines_filter_map_ok)]
 pub fn read_log_entries(file_path: &Path) -> std::io::Result<Vec<LogEntry>> {
     let file = File::open(file_path)?;
     let reader = BufReader::new(file);
@@ -1787,7 +1791,7 @@ mod tests {
             .position(|l| l.starts_with("2. "))
             .expect("Should find '2. '");
         assert!(
-            line2_idx >= 1 && line2_idx <= 4,
+            (1..=4).contains(&line2_idx),
             "Second item should appear after first"
         );
     }

--- a/src/tui/viewer.rs
+++ b/src/tui/viewer.rs
@@ -4,7 +4,9 @@
 //! in the TUI viewer. It produces styled spans that ratatui can render directly,
 //! without using ANSI escape codes.
 
-use crate::claude::{AssistantMessage, ContentBlock, LogEntry, UserContent};
+use crate::claude::{
+    AssistantMessage, ContentBlock, LogEntry, UserContent, extract_tool_result_text,
+};
 use crate::text_processing::{process_command_message, short_agent_id};
 use crate::tool_format;
 use crate::tui::app::{LineStyle, RenderedLine};
@@ -238,28 +240,6 @@ fn render_user_message(
 
     if printed {
         lines.push(RenderedLine { spans: vec![] }); // Empty line after message
-    }
-}
-
-/// Extract text content from tool result for markdown rendering.
-/// Returns Some(text) if content is a string or array of text blocks.
-/// Returns None for JSON structures that should be pretty-printed instead.
-fn extract_tool_result_text(content: Option<&serde_json::Value>) -> Option<String> {
-    match content {
-        Some(serde_json::Value::String(s)) => Some(s.clone()),
-        Some(serde_json::Value::Array(arr)) => {
-            // Handle array of content blocks (e.g., [{type: "text", text: "..."}])
-            let texts: Vec<&str> = arr
-                .iter()
-                .filter_map(|item| item.get("text").and_then(|t| t.as_str()))
-                .collect();
-            if !texts.is_empty() {
-                Some(texts.join("\n\n"))
-            } else {
-                None // Array without text blocks - render as JSON
-            }
-        }
-        _ => None, // Objects, null, etc. - render as JSON
     }
 }
 

--- a/src/tui/viewer.rs
+++ b/src/tui/viewer.rs
@@ -293,7 +293,14 @@ fn render_assistant_message(
                 continue;
             }
             let md_lines = render_markdown_to_lines(text, options.content_width);
-            render_ledger_block_styled(lines, &options.assistant_label, options.assistant_color, true, md_lines, ts_remaining);
+            render_ledger_block_styled(
+                lines,
+                &options.assistant_label,
+                options.assistant_color,
+                true,
+                md_lines,
+                ts_remaining,
+            );
             printed = true;
             // After first block consumes the timestamp, use blank padding for alignment
             if ts_remaining.is_some() {
@@ -348,7 +355,14 @@ fn render_assistant_message(
                 } else {
                     None
                 };
-                render_ledger_block_styled(lines, "Thinking", options.assistant_dim_color, false, styled_lines, ts);
+                render_ledger_block_styled(
+                    lines,
+                    "Thinking",
+                    options.assistant_dim_color,
+                    false,
+                    styled_lines,
+                    ts,
+                );
                 printed = true;
             }
         }
@@ -1556,7 +1570,6 @@ fn render_continuation_dimmed(lines: &mut Vec<RenderedLine>, text: &str, show_ti
         lines.push(RenderedLine { spans });
     }
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Adds a stable, non-interactive CLI surface so tools and skills can analyze conversation history (Claude Code, Codex, Cursor Agent, Cursor IDE) without scraping the TUI. Reuses the existing provider, parser, cache, and loading code paths; TUI behavior is unchanged.

```bash
mnemonai list --json                              # all conversations as a JSON array
mnemonai list --jsonl --provider codex --limit 100 # stream summaries as JSONL
mnemonai show <session-id|path> --json             # one conversation, normalized
```

- `list` — load conversations and emit `ConversationSummary` objects (JSON array or JSONL), with `--provider`, `--local`, `--show-deleted-projects`, and `--limit`.
- `show <id-or-path>` — resolve by exact path, file stem, or unique session id, then emit a provider-independent `ConversationDetail` (normalized text / tool calls / tool results / thinking / image / system / sub-agent messages).
- New `Command` enum and `ProviderFilter` in `cli.rs`; headless dispatch lives in `headless.rs` and runs before the TUI is ever entered.

## Robustness & schema hardening

- **Pipe-safe output:** output is serialized to a buffer and written once, and `io::ErrorKind::BrokenPipe` is treated as a clean exit, so `mnemonai list --json | head` exits 0 instead of printing a misleading "JSON parsing error".
- **System metadata:** the System log `level` ("info"/"warning"/...) is surfaced in its own `level` field instead of leaking into message `text`.
- **Better errors:** the ambiguous-`show` error suggests `--provider`; a bare word that looks like a mistyped subcommand (e.g. `dump`) hints to check `--help`.

## Refactor / de-duplication

- Extract `loader::load_local`, shared by the TUI path and the headless commands, so both apply identical provider/local filtering.
- Promote `claude::extract_tool_result_text` and `history::path_to_string`, dropping duplicate copies in the viewer, headless, and conversation index.

## Tests

`cargo test` (200 tests) and `cargo clippy` pass. Added coverage for path/file-stem resolution, unknown-target and ambiguity errors, message normalization (summary / tool_result / image / system, empty-text skipping), JSONL line shape, provider filtering, and a `read_entries → messages` round-trip on a temp Claude JSONL fixture.

See `docs/headless-cli-plan.md` for the full design.