### PR TITLE
Expose tool traces in headless JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ mnemonai list --json
 # Stream conversation summaries as JSONL (one object per line)
 mnemonai list --jsonl --provider codex --limit 100
 
+# Scope list output for retrospective analysis
+mnemonai list --json --since 7d --limit 50
+mnemonai list --json --cwd ~/code/my-repo --after 2026-06-01 --before 2026-06-20
+
 # Show one conversation by session ID or source path
 mnemonai show <session-id-or-path> --json
 
@@ -61,8 +65,13 @@ mnemonai list --jsonl --limit 500 | jq -r 'select(.message_count > 50) | .id'
 
 `list` and `show` accept `--provider <claude|codex|cursor|cursor-agent>`,
 `--local` (current directory only), and `--show-deleted-projects`. `list` also
-takes `--limit <n>`. Output is JSON by default; on errors (no match, ambiguous
-target) the command prints a message to stderr and exits non-zero.
+takes `--limit <n>`, `--since <duration>` (for example `7d`, `24h`, `2w`),
+`--after <timestamp>`, `--before <timestamp>`, and `--cwd <path>`.
+`--after`/`--before` accept RFC 3339 timestamps or `YYYY-MM-DD`; the lower bound
+is inclusive and the upper bound is exclusive. `--cwd` matches conversations
+whose recorded `cwd` or `project_path` is at or under the path. Output is JSON by
+default; on errors (no match, ambiguous target) the command prints a message to
+stderr and exits non-zero.
 
 ### `list` output — conversation summary
 
@@ -93,21 +102,29 @@ carries `role` plus whichever of these apply (absent fields are omitted):
 
 | Field | Populated for |
 |-------|---------------|
+| `index` | always — zero-based normalized message index |
+| `entry_index` | always — zero-based source log entry index |
+| `block_index` | content-block messages, when applicable |
 | `role` | always — one of `summary`, `user`, `assistant`, `tool_call`, `tool_result`, `thinking`, `image`, `system`, or `agent_<type>` for sub-agent turns |
 | `timestamp` | most messages (RFC 3339) |
 | `text` | text messages, tool results, summaries |
+| `tool_call_id` | `tool_call` and `tool_result`; use this to pair calls with results |
 | `tool_name` | `tool_call` |
 | `tool_input` | `tool_call` — raw, tool-specific JSON (opaque) |
 | `tool_result` | `tool_result` — raw, provider-specific JSON (opaque) |
+| `tool_result_status` | `tool_result`, when the provider exposes status |
+| `tool_result_exit_code` | `tool_result`, when command-style output exposes an exit code |
+| `tool_result_error` | `tool_result`, when an explicit or recognizable error/success marker exists |
 | `thinking` | `thinking` |
 | `model` | assistant/thinking, when available |
 | `agent_id` | sub-agent messages |
 | `subtype` / `level` / `duration_ms` | `system` |
 | `source` | `image` — raw provider-specific image source (opaque) |
 
-`tool_input`, `tool_result`, and `source` are passed through verbatim from the
-underlying transcript; treat their inner shape as opaque rather than a stable
-contract.
+`tool_call_id`, `index`, `entry_index`, and `block_index` are intended for
+tool-trace analysis. `tool_input`, `tool_result`, and `source` are passed
+through verbatim from the underlying transcript; treat their inner shape as
+opaque rather than a stable contract.
 
 ## Keyboard Shortcuts
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ whose recorded `cwd` or `project_path` is at or under the path. Output is JSON b
 default; on errors (no match, ambiguous target) the command prints a message to
 stderr and exits non-zero.
 
+Headless output depends only on these flags, never on the config file: unlike the
+interactive TUI, `list`/`show` ignore the config's `local`, `exclude`, and
+`show_deleted_projects` settings so scripts and skills get the same result on any
+machine. Pass `--local` / `--show-deleted-projects` explicitly when you want them.
+
 ### `list` output — conversation summary
 
 Each conversation is an object with these fields (nullable fields are omitted

--- a/docs/headless-cli-plan.md
+++ b/docs/headless-cli-plan.md
@@ -27,7 +27,7 @@ Use subcommands for new machine-readable behavior while keeping existing flags
 working for interactive usage.
 
 ```text
-mnemonai list [--json|--jsonl] [--local] [--provider <name>] [--limit <n>] [--show-deleted-projects]
+mnemonai list [--json|--jsonl] [--local|--cwd <path>] [--provider <name>] [--since <duration>] [--after <timestamp>] [--before <timestamp>] [--limit <n>] [--show-deleted-projects]
 mnemonai show <id-or-path> [--json|--jsonl|--plain|--ledger] [--show-tools] [--show-thinking]
 mnemonai dump [--jsonl] [--local] [--provider <name>] [--since <duration>] [--limit <n>]
 mnemonai search <query> [--json|--jsonl] [--local] [--provider <name>] [--limit <n>]
@@ -77,13 +77,31 @@ Used by `show` and `dump --include-messages` if added.
   "conversation": { "provider": "claude", "id": "session-id" },
   "messages": [
     {
+      "index": 0,
+      "entry_index": 1,
       "role": "user",
       "timestamp": "2026-06-19T10:12:33-07:00",
-      "text": "message text",
-      "tool_name": null,
-      "tool_input": null,
-      "tool_result": null,
-      "thinking": null
+      "text": "message text"
+    },
+    {
+      "index": 1,
+      "entry_index": 2,
+      "block_index": 0,
+      "role": "tool_call",
+      "tool_call_id": "toolu_123",
+      "tool_name": "Bash",
+      "tool_input": { "command": "cargo test --all" }
+    },
+    {
+      "index": 2,
+      "entry_index": 3,
+      "block_index": 0,
+      "role": "tool_result",
+      "tool_call_id": "toolu_123",
+      "text": "test output",
+      "tool_result_status": "failed",
+      "tool_result_exit_code": 1,
+      "tool_result_error": true
     }
   ]
 }
@@ -91,6 +109,9 @@ Used by `show` and `dump --include-messages` if added.
 
 Keep the schema intentionally simple for skill consumption. Include raw source
 path and provider ID so a caller can re-open or resume with existing tools.
+For tool analysis, pair `tool_call` and `tool_result` messages by
+`tool_call_id` and use `index`, `entry_index`, and `block_index` to reconstruct
+the execution trace.
 
 ## Implementation Phases
 

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -112,10 +112,13 @@ pub enum ContentBlock {
         input: serde_json::Value,
     },
     ToolResult {
-        #[allow(dead_code)]
         tool_use_id: String,
         #[serde(default)]
         content: Option<serde_json::Value>, // Optional in some user tool result entries
+        #[serde(default)]
+        is_error: Option<bool>,
+        #[serde(default)]
+        status: Option<String>,
     },
     Thinking {
         thinking: String,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -211,6 +211,22 @@ pub struct ListCommand {
     #[arg(long)]
     pub local: bool,
 
+    /// Only include conversations whose cwd or project path is at or under this path
+    #[arg(long, value_name = "PATH", conflicts_with = "local")]
+    pub cwd: Option<PathBuf>,
+
+    /// Only include conversations from the last duration (for example: 7d, 24h, 2w)
+    #[arg(long, value_name = "DURATION", conflicts_with = "after")]
+    pub since: Option<String>,
+
+    /// Only include conversations at or after this timestamp (RFC 3339 or YYYY-MM-DD)
+    #[arg(long, value_name = "TIMESTAMP")]
+    pub after: Option<String>,
+
+    /// Only include conversations before this timestamp (RFC 3339 or YYYY-MM-DD)
+    #[arg(long, value_name = "TIMESTAMP")]
+    pub before: Option<String>,
+
     /// Include conversations from deleted project directories
     #[arg(long)]
     pub show_deleted_projects: bool,
@@ -254,6 +270,10 @@ mod tests {
             "--jsonl",
             "--provider",
             "cursor-agent",
+            "--since",
+            "7d",
+            "--cwd",
+            ".",
             "--limit",
             "10",
         ])
@@ -263,6 +283,8 @@ mod tests {
             Some(Command::List(command)) => {
                 assert!(command.jsonl);
                 assert_eq!(command.provider, Some(ProviderFilter::CursorAgent));
+                assert_eq!(command.since.as_deref(), Some("7d"));
+                assert_eq!(command.cwd, Some(PathBuf::from(".")));
                 assert_eq!(command.limit, Some(10));
             }
             other => panic!("expected list command, got {:?}", other),

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -16,7 +16,6 @@ use std::path::{Path, PathBuf};
 
 pub struct HeadlessSettings {
     pub cli_local: bool,
-    pub config_local: bool,
     pub show_last: bool,
     pub show_deleted_projects: bool,
     pub debug: Option<DebugLevel>,
@@ -237,7 +236,7 @@ fn load_conversations(
     command_show_deleted: bool,
     force_global: bool,
 ) -> Result<Vec<Conversation>> {
-    let local = !force_global && (command_local || settings.cli_local || settings.config_local);
+    let local = use_local_scope(settings, command_local, force_global);
     let show_deleted_projects = command_show_deleted || settings.show_deleted_projects;
     let mut conversations = if local {
         crate::loader::load_local(
@@ -268,6 +267,13 @@ fn load_conversations(
     reindex_conversations(&mut conversations);
 
     Ok(conversations)
+}
+
+fn use_local_scope(settings: &HeadlessSettings, command_local: bool, force_global: bool) -> bool {
+    // Headless commands default to global output even when the interactive TUI
+    // config has `local = true`; scripts and skills need stable scope unless the
+    // caller explicitly passes --local.
+    !force_global && (command_local || settings.cli_local)
 }
 
 fn apply_list_filters(conversations: &mut Vec<Conversation>, command: &ListCommand) -> Result<()> {
@@ -1238,6 +1244,34 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(root);
         let _ = std::fs::remove_dir_all(other);
+    }
+
+    #[test]
+    fn headless_scope_is_global_without_explicit_local_flag() {
+        let settings = HeadlessSettings {
+            cli_local: false,
+            show_last: false,
+            show_deleted_projects: false,
+            debug: None,
+        };
+
+        assert!(
+            !use_local_scope(&settings, false, false),
+            "headless commands must default to global scope"
+        );
+        assert!(use_local_scope(&settings, true, false));
+
+        let cli_settings = HeadlessSettings {
+            cli_local: true,
+            show_last: false,
+            show_deleted_projects: false,
+            debug: None,
+        };
+        assert!(use_local_scope(&cli_settings, false, false));
+        assert!(
+            !use_local_scope(&cli_settings, true, true),
+            "--cwd must force global loading before cwd filtering"
+        );
     }
 
     #[test]

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -8,10 +8,11 @@ use crate::history::{
     Conversation, LoaderMessage, ParseError, path_to_string, project_path_is_live,
 };
 use crate::providers::Provider;
+use chrono::{DateTime, Duration, Local, NaiveDate, TimeZone};
 use serde::Serialize;
 use serde_json::Value;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub struct HeadlessSettings {
     pub cli_local: bool,
@@ -47,17 +48,29 @@ struct ConversationDetail {
 
 #[derive(Serialize)]
 struct MessageDto {
+    index: usize,
+    entry_index: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    block_index: Option<usize>,
     role: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     timestamp: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     text: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     tool_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_input: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_result: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_result_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_result_exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_result_error: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     thinking: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -74,15 +87,63 @@ struct MessageDto {
     source: Option<Value>,
 }
 
-impl MessageDto {
-    fn new(role: impl Into<String>, timestamp: Option<&str>) -> Self {
+#[derive(Clone, Copy)]
+struct MessageContext<'a> {
+    timestamp: Option<&'a str>,
+    model: Option<&'a str>,
+    agent_id: Option<&'a str>,
+    entry_index: usize,
+    block_index: Option<usize>,
+}
+
+impl<'a> MessageContext<'a> {
+    fn new(entry_index: usize) -> Self {
         Self {
+            timestamp: None,
+            model: None,
+            agent_id: None,
+            entry_index,
+            block_index: None,
+        }
+    }
+
+    fn timestamp(mut self, timestamp: &'a str) -> Self {
+        self.timestamp = Some(timestamp);
+        self
+    }
+
+    fn model(mut self, model: Option<&'a str>) -> Self {
+        self.model = model;
+        self
+    }
+
+    fn agent_id(mut self, agent_id: Option<&'a str>) -> Self {
+        self.agent_id = agent_id;
+        self
+    }
+
+    fn block_index(mut self, block_index: Option<usize>) -> Self {
+        self.block_index = block_index;
+        self
+    }
+}
+
+impl MessageDto {
+    fn new(role: impl Into<String>, context: MessageContext<'_>) -> Self {
+        Self {
+            index: 0,
+            entry_index: context.entry_index,
+            block_index: context.block_index,
             role: role.into(),
-            timestamp: timestamp.map(ToString::to_string),
+            timestamp: context.timestamp.map(ToString::to_string),
             text: None,
+            tool_call_id: None,
             tool_name: None,
             tool_input: None,
             tool_result: None,
+            tool_result_status: None,
+            tool_result_exit_code: None,
+            tool_result_error: None,
             thinking: None,
             model: None,
             agent_id: None,
@@ -116,10 +177,13 @@ fn run_list(
         command.provider,
         command.local,
         command.show_deleted_projects,
+        command.cwd.is_some(),
     )?;
+    apply_list_filters(&mut conversations, command)?;
     if let Some(limit) = command.limit {
         conversations.truncate(limit);
     }
+    reindex_conversations(&mut conversations);
 
     let summaries: Vec<_> = conversations
         .iter()
@@ -144,6 +208,7 @@ fn run_show(
         command.provider,
         command.local,
         command.show_deleted_projects,
+        false,
     )?;
     let conversation = resolve_conversation(&conversations, &command.target)?;
     let provider = providers
@@ -170,8 +235,9 @@ fn load_conversations(
     provider_filter: Option<ProviderFilter>,
     command_local: bool,
     command_show_deleted: bool,
+    force_global: bool,
 ) -> Result<Vec<Conversation>> {
-    let local = command_local || settings.cli_local || settings.config_local;
+    let local = !force_global && (command_local || settings.cli_local || settings.config_local);
     let show_deleted_projects = command_show_deleted || settings.show_deleted_projects;
     let mut conversations = if local {
         crate::loader::load_local(
@@ -199,11 +265,152 @@ fn load_conversations(
     }
 
     conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    reindex_conversations(&mut conversations);
+
+    Ok(conversations)
+}
+
+fn apply_list_filters(conversations: &mut Vec<Conversation>, command: &ListCommand) -> Result<()> {
+    let after = list_after_cutoff(command)?;
+    let before = command
+        .before
+        .as_deref()
+        .map(|value| parse_timestamp_filter(value, "--before"))
+        .transpose()?;
+    let cwd_roots = command.cwd.as_deref().map(filter_path_roots).transpose()?;
+
+    conversations.retain(|conversation| {
+        after.is_none_or(|after| conversation.timestamp >= after)
+            && before.is_none_or(|before| conversation.timestamp < before)
+            && cwd_roots
+                .as_ref()
+                .is_none_or(|roots| conversation_matches_cwd(conversation, roots))
+    });
+
+    Ok(())
+}
+
+fn list_after_cutoff(command: &ListCommand) -> Result<Option<DateTime<Local>>> {
+    if let Some(since) = command.since.as_deref() {
+        let duration = parse_since_duration(since)?;
+        let cutoff = Local::now()
+            .checked_sub_signed(duration)
+            .ok_or_else(|| invalid_duration(since))?;
+        Ok(Some(cutoff))
+    } else {
+        command
+            .after
+            .as_deref()
+            .map(|value| parse_timestamp_filter(value, "--after"))
+            .transpose()
+    }
+}
+
+fn parse_since_duration(value: &str) -> Result<Duration> {
+    let trimmed = value.trim();
+    let unit_start = trimmed
+        .find(|ch: char| !ch.is_ascii_digit())
+        .ok_or_else(|| invalid_duration(value))?;
+    let (amount, unit) = trimmed.split_at(unit_start);
+    if amount.is_empty() || unit.is_empty() || unit.chars().any(char::is_whitespace) {
+        return Err(invalid_duration(value));
+    }
+
+    let amount = amount.parse::<i64>().map_err(|_| invalid_duration(value))?;
+    if amount <= 0 {
+        return Err(invalid_duration(value));
+    }
+
+    // Use the checked constructors: an out-of-range amount (e.g. 9999999999999w)
+    // would otherwise panic inside chrono rather than return a clean error.
+    let duration = match unit.to_ascii_lowercase().as_str() {
+        "m" | "min" | "mins" | "minute" | "minutes" => Duration::try_minutes(amount),
+        "h" | "hr" | "hrs" | "hour" | "hours" => Duration::try_hours(amount),
+        "d" | "day" | "days" => Duration::try_days(amount),
+        "w" | "week" | "weeks" => Duration::try_weeks(amount),
+        _ => return Err(invalid_duration(value)),
+    };
+    duration.ok_or_else(|| invalid_duration(value))
+}
+
+fn invalid_duration(value: &str) -> AppError {
+    AppError::CommandError(format!(
+        "Invalid --since value '{}'; expected a positive duration like 7d, 24h, or 2w",
+        value
+    ))
+}
+
+fn parse_timestamp_filter(value: &str, flag: &str) -> Result<DateTime<Local>> {
+    if let Ok(timestamp) = DateTime::parse_from_rfc3339(value) {
+        return Ok(timestamp.with_timezone(&Local));
+    }
+
+    if let Ok(date) = NaiveDate::parse_from_str(value, "%Y-%m-%d") {
+        let midnight = date
+            .and_hms_opt(0, 0, 0)
+            .ok_or_else(|| invalid_timestamp(value, flag))?;
+        // `.single()` is None when local midnight falls in a DST spring-forward
+        // gap; fall back to the earliest valid instant so a real date is never
+        // rejected purely because of a timezone transition.
+        return Local
+            .from_local_datetime(&midnight)
+            .earliest()
+            .ok_or_else(|| invalid_timestamp(value, flag));
+    }
+
+    Err(invalid_timestamp(value, flag))
+}
+
+fn invalid_timestamp(value: &str, flag: &str) -> AppError {
+    AppError::CommandError(format!(
+        "Invalid {} value '{}'; expected RFC 3339 or YYYY-MM-DD",
+        flag, value
+    ))
+}
+
+/// Candidate root forms for a `--cwd` filter: the absolutized literal path and,
+/// when it resolves, its canonical (symlink-resolved) form. A conversation path
+/// is matched against both because a recorded cwd that no longer exists on disk
+/// can't be canonicalized, so it would otherwise fail to match a canonical root
+/// even when it is genuinely under the path (e.g. `/tmp` vs `/private/tmp`).
+fn filter_path_roots(path: &Path) -> Result<Vec<PathBuf>> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+
+    let mut roots = Vec::with_capacity(2);
+    if let Ok(canonical) = absolute.canonicalize()
+        && canonical != absolute
+    {
+        roots.push(canonical);
+    }
+    roots.push(absolute);
+    Ok(roots)
+}
+
+fn conversation_matches_cwd(conversation: &Conversation, roots: &[PathBuf]) -> bool {
+    conversation
+        .cwd
+        .as_ref()
+        .into_iter()
+        .chain(conversation.project_path.as_ref())
+        .any(|path| path_at_or_under(path, roots))
+}
+
+fn path_at_or_under(path: &Path, roots: &[PathBuf]) -> bool {
+    let canonical = path.canonicalize();
+    let candidates = canonical.iter().map(PathBuf::as_path).chain([path]);
+    candidates
+        .into_iter()
+        .any(|candidate| roots.iter().any(|root| candidate.starts_with(root)))
+}
+
+fn reindex_conversations(conversations: &mut [Conversation]) {
     for (idx, conversation) in conversations.iter_mut().enumerate() {
         conversation.index = idx;
     }
-
-    Ok(conversations)
 }
 
 fn load_global_conversations(
@@ -319,35 +526,31 @@ impl ConversationSummary {
 
 fn messages_from_entries(entries: &[LogEntry]) -> Vec<MessageDto> {
     let mut messages = Vec::new();
-    for entry in entries {
+    for (entry_index, entry) in entries.iter().enumerate() {
         match entry {
             LogEntry::Summary { summary } => {
-                let mut message = MessageDto::new("summary", None);
+                let mut message = MessageDto::new("summary", MessageContext::new(entry_index));
                 message.text = Some(summary.clone());
-                messages.push(message);
+                push_message(&mut messages, message);
             }
             LogEntry::User {
                 message,
                 timestamp,
                 cwd: _,
                 ..
-            } => push_user_message(&mut messages, message, timestamp),
+            } => push_user_message(&mut messages, message, timestamp, entry_index),
             LogEntry::Assistant {
                 message, timestamp, ..
-            } => push_assistant_message(&mut messages, message, timestamp),
+            } => push_assistant_message(&mut messages, message, timestamp, entry_index),
             LogEntry::Progress { data, .. } => {
                 if let Some(progress) = parse_agent_progress(data) {
                     let AgentContent::Blocks(blocks) = &progress.message.message.content;
                     let role = format!("agent_{}", progress.message.message_type);
-                    for block in blocks {
-                        push_content_block(
-                            &mut messages,
-                            &role,
-                            None,
-                            None,
-                            Some(progress.agent_id.as_str()),
-                            block,
-                        );
+                    for (block_index, block) in blocks.iter().enumerate() {
+                        let context = MessageContext::new(entry_index)
+                            .agent_id(Some(progress.agent_id.as_str()))
+                            .block_index(Some(block_index));
+                        push_content_block(&mut messages, &role, block, context);
                     }
                 }
             }
@@ -357,13 +560,13 @@ fn messages_from_entries(entries: &[LogEntry]) -> Vec<MessageDto> {
                 duration_ms,
                 ..
             } => {
-                let mut message = MessageDto::new("system", None);
+                let mut message = MessageDto::new("system", MessageContext::new(entry_index));
                 message.subtype = Some(subtype.clone());
                 // `level` is a log severity ("info"/"warning"/...), not chat
                 // content, so keep it out of the `text` field consumers read.
                 message.level = level.clone();
                 message.duration_ms = *duration_ms;
-                messages.push(message);
+                push_message(&mut messages, message);
             }
             LogEntry::FileHistorySnapshot { .. } | LogEntry::Unknown => {}
         }
@@ -371,18 +574,28 @@ fn messages_from_entries(entries: &[LogEntry]) -> Vec<MessageDto> {
     messages
 }
 
+fn push_message(messages: &mut Vec<MessageDto>, mut message: MessageDto) {
+    message.index = messages.len();
+    messages.push(message);
+}
+
 fn push_user_message(
     messages: &mut Vec<MessageDto>,
     message: &crate::claude::UserMessage,
     timestamp: &str,
+    entry_index: usize,
 ) {
     match &message.content {
         UserContent::String(text) => {
-            push_text_message(messages, "user", Some(timestamp), None, None, text);
+            let context = MessageContext::new(entry_index).timestamp(timestamp);
+            push_text_message(messages, "user", text, context);
         }
         UserContent::Blocks(blocks) => {
-            for block in blocks {
-                push_content_block(messages, "user", Some(timestamp), None, None, block);
+            for (block_index, block) in blocks.iter().enumerate() {
+                let context = MessageContext::new(entry_index)
+                    .timestamp(timestamp)
+                    .block_index(Some(block_index));
+                push_content_block(messages, "user", block, context);
             }
         }
     }
@@ -392,58 +605,70 @@ fn push_assistant_message(
     messages: &mut Vec<MessageDto>,
     message: &crate::claude::AssistantMessage,
     timestamp: &str,
+    entry_index: usize,
 ) {
-    for block in &message.content {
-        push_content_block(
-            messages,
-            "assistant",
-            Some(timestamp),
-            message.model.as_deref(),
-            None,
-            block,
-        );
+    for (block_index, block) in message.content.iter().enumerate() {
+        let context = MessageContext::new(entry_index)
+            .timestamp(timestamp)
+            .model(message.model.as_deref())
+            .block_index(Some(block_index));
+        push_content_block(messages, "assistant", block, context);
     }
 }
 
 fn push_content_block(
     messages: &mut Vec<MessageDto>,
     text_role: &str,
-    timestamp: Option<&str>,
-    model: Option<&str>,
-    agent_id: Option<&str>,
     block: &ContentBlock,
+    context: MessageContext<'_>,
 ) {
     match block {
         ContentBlock::Text { text } => {
-            push_text_message(messages, text_role, timestamp, model, agent_id, text);
+            push_text_message(messages, text_role, text, context);
         }
-        ContentBlock::ToolUse { name, input, .. } => {
-            let mut message = MessageDto::new("tool_call", timestamp);
+        ContentBlock::ToolUse { id, name, input } => {
+            let mut message = MessageDto::new("tool_call", context);
+            message.tool_call_id = Some(id.clone());
             message.tool_name = Some(name.clone());
             message.tool_input = Some(input.clone());
-            message.model = model.map(ToString::to_string);
-            message.agent_id = agent_id.map(ToString::to_string);
-            messages.push(message);
+            message.model = context.model.map(ToString::to_string);
+            message.agent_id = context.agent_id.map(ToString::to_string);
+            push_message(messages, message);
         }
-        ContentBlock::ToolResult { content, .. } => {
-            let mut message = MessageDto::new("tool_result", timestamp);
+        ContentBlock::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+            status,
+        } => {
+            let mut message = MessageDto::new("tool_result", context);
+            message.tool_call_id = Some(tool_use_id.clone());
             message.text = extract_tool_result_text(content.as_ref());
-            message.tool_result = content.clone();
-            message.agent_id = agent_id.map(ToString::to_string);
-            messages.push(message);
+            // Omit an empty result body rather than emitting `"tool_result": null`
+            // (some providers default missing content to JSON null).
+            message.tool_result = content.clone().filter(|value| !value.is_null());
+            message.tool_result_status = status.clone();
+            message.tool_result_exit_code = message.text.as_deref().and_then(tool_result_exit_code);
+            message.tool_result_error = merge_error_markers(&[
+                *is_error,
+                message.tool_result_exit_code.map(|code| code != 0),
+                status.as_deref().and_then(status_is_error),
+            ]);
+            message.agent_id = context.agent_id.map(ToString::to_string);
+            push_message(messages, message);
         }
         ContentBlock::Thinking { thinking, .. } => {
-            let mut message = MessageDto::new("thinking", timestamp);
+            let mut message = MessageDto::new("thinking", context);
             message.thinking = Some(thinking.clone());
-            message.model = model.map(ToString::to_string);
-            message.agent_id = agent_id.map(ToString::to_string);
-            messages.push(message);
+            message.model = context.model.map(ToString::to_string);
+            message.agent_id = context.agent_id.map(ToString::to_string);
+            push_message(messages, message);
         }
         ContentBlock::Image { source } => {
-            let mut message = MessageDto::new("image", timestamp);
+            let mut message = MessageDto::new("image", context);
             message.source = Some(source.clone());
-            message.agent_id = agent_id.map(ToString::to_string);
-            messages.push(message);
+            message.agent_id = context.agent_id.map(ToString::to_string);
+            push_message(messages, message);
         }
     }
 }
@@ -451,20 +676,46 @@ fn push_content_block(
 fn push_text_message(
     messages: &mut Vec<MessageDto>,
     role: &str,
-    timestamp: Option<&str>,
-    model: Option<&str>,
-    agent_id: Option<&str>,
     text: &str,
+    context: MessageContext<'_>,
 ) {
     if text.trim().is_empty() {
         return;
     }
 
-    let mut message = MessageDto::new(role, timestamp);
+    let mut message = MessageDto::new(role, context);
     message.text = Some(text.to_string());
-    message.model = model.map(ToString::to_string);
-    message.agent_id = agent_id.map(ToString::to_string);
-    messages.push(message);
+    message.model = context.model.map(ToString::to_string);
+    message.agent_id = context.agent_id.map(ToString::to_string);
+    push_message(messages, message);
+}
+
+fn status_is_error(status: &str) -> Option<bool> {
+    match status.to_ascii_lowercase().as_str() {
+        "error" | "errored" | "failed" | "failure" | "cancelled" | "canceled" => Some(true),
+        "success" | "succeeded" | "complete" | "completed" | "ok" | "done" => Some(false),
+        other if other.contains("error") || other.contains("fail") => Some(true),
+        _ => None,
+    }
+}
+
+fn tool_result_exit_code(text: &str) -> Option<i32> {
+    const MARKER: &str = "Process exited with code ";
+
+    text.lines().take(8).find_map(|line| {
+        let rest = line.trim().strip_prefix(MARKER)?;
+        rest.split_whitespace().next()?.parse().ok()
+    })
+}
+
+fn merge_error_markers(markers: &[Option<bool>]) -> Option<bool> {
+    if markers.contains(&Some(true)) {
+        Some(true)
+    } else if markers.iter().any(Option::is_some) {
+        Some(false)
+    } else {
+        None
+    }
 }
 
 fn json_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>> {
@@ -588,9 +839,17 @@ mod tests {
         let messages = messages_from_entries(&entries);
 
         assert_eq!(messages.len(), 4);
+        assert_eq!(messages[0].index, 0);
+        assert_eq!(messages[0].entry_index, 0);
+        assert_eq!(messages[0].block_index, None);
         assert_eq!(messages[0].role, "user");
         assert_eq!(messages[1].role, "assistant");
+        assert_eq!(messages[1].entry_index, 1);
+        assert_eq!(messages[1].block_index, Some(0));
         assert_eq!(messages[2].role, "tool_call");
+        assert_eq!(messages[2].entry_index, 1);
+        assert_eq!(messages[2].block_index, Some(1));
+        assert_eq!(messages[2].tool_call_id.as_deref(), Some("tool-1"));
         assert_eq!(messages[2].tool_name.as_deref(), Some("Bash"));
         assert_eq!(messages[3].role, "thinking");
         assert_eq!(messages[3].model.as_deref(), Some("claude-test"));
@@ -694,6 +953,8 @@ mod tests {
                                 {"type": "text", "text": "line one"},
                                 {"type": "text", "text": "line two"},
                             ])),
+                            is_error: Some(true),
+                            status: Some("failed".to_string()),
                         },
                         ContentBlock::Image {
                             source: serde_json::json!({"type": "base64", "media_type": "image/png"}),
@@ -723,6 +984,9 @@ mod tests {
         assert_eq!(messages[0].text.as_deref(), Some("Session title"));
 
         assert_eq!(messages[1].text.as_deref(), Some("line one\n\nline two"));
+        assert_eq!(messages[1].tool_call_id.as_deref(), Some("t1"));
+        assert_eq!(messages[1].tool_result_status.as_deref(), Some("failed"));
+        assert_eq!(messages[1].tool_result_error, Some(true));
         assert!(messages[1].tool_result.is_some());
 
         assert!(messages[2].source.is_some());
@@ -764,6 +1028,291 @@ mod tests {
         let second: Value = serde_json::from_str(lines[1]).unwrap();
         assert_eq!(first["id"], "a");
         assert_eq!(second["id"], "b");
+    }
+
+    #[test]
+    fn parses_since_duration_values() {
+        assert_eq!(parse_since_duration("15m").unwrap(), Duration::minutes(15));
+        assert_eq!(parse_since_duration("24h").unwrap(), Duration::hours(24));
+        assert_eq!(parse_since_duration("7d").unwrap(), Duration::days(7));
+        assert_eq!(parse_since_duration("2w").unwrap(), Duration::weeks(2));
+        assert!(parse_since_duration("0d").is_err());
+        assert!(parse_since_duration("soon").is_err());
+    }
+
+    #[test]
+    fn since_overflow_is_a_clean_error_not_a_panic() {
+        // Parseable but out-of-range amounts must not panic inside chrono.
+        assert!(parse_since_duration("9999999999999w").is_err());
+        assert!(parse_since_duration("9999999999999d").is_err());
+
+        // A duration that fits in TimeDelta but overflows the now() subtraction
+        // must also surface as a clean error rather than panicking.
+        let command = ListCommand {
+            json: false,
+            jsonl: false,
+            provider: None,
+            local: false,
+            cwd: None,
+            since: Some("200000000d".to_string()),
+            after: None,
+            before: None,
+            show_deleted_projects: false,
+            limit: None,
+        };
+        assert!(list_after_cutoff(&command).is_err());
+    }
+
+    #[test]
+    fn after_is_inclusive_and_before_is_exclusive() {
+        let make = |id: &str, h: u32, m: u32| {
+            let mut c = conversation(id, &format!("/tmp/{id}.jsonl"), ProviderKind::Claude);
+            c.timestamp = Local
+                .with_ymd_and_hms(2026, 6, 19, h, m, 0)
+                .single()
+                .unwrap();
+            c
+        };
+        // Window is [09:00, 17:00): the conversation exactly on --after must stay,
+        // the one exactly on --before must drop.
+        let mut conversations = vec![
+            make("before_after", 8, 59),
+            make("on_after", 9, 0),
+            make("inside", 12, 0),
+            make("on_before", 17, 0),
+        ];
+
+        // Build RFC 3339 bounds in the local offset so the test is timezone-stable.
+        let offset = Local
+            .with_ymd_and_hms(2026, 6, 19, 0, 0, 0)
+            .single()
+            .unwrap()
+            .format("%:z")
+            .to_string();
+        let command = ListCommand {
+            json: false,
+            jsonl: false,
+            provider: None,
+            local: false,
+            cwd: None,
+            since: None,
+            after: Some(format!("2026-06-19T09:00:00{offset}")),
+            before: Some(format!("2026-06-19T17:00:00{offset}")),
+            show_deleted_projects: false,
+            limit: None,
+        };
+        apply_list_filters(&mut conversations, &command).unwrap();
+
+        let ids: Vec<_> = conversations.iter().map(|c| c.id.as_str()).collect();
+        assert_eq!(ids, vec!["on_after", "inside"]);
+    }
+
+    #[test]
+    fn cwd_filter_keeps_conversation_whose_recorded_dir_is_deleted() {
+        // A recorded cwd that no longer exists on disk can't be canonicalized;
+        // it must still match a --cwd root it is genuinely under (regression for
+        // the /tmp -> /private/tmp symlink asymmetry on macOS).
+        let root =
+            std::env::temp_dir().join(format!("mnemonai-headless-cwd-{}", std::process::id()));
+        std::fs::create_dir_all(&root).unwrap();
+        let gone = root.join("torn-down-worktree");
+
+        let mut kept = conversation("kept", "/tmp/kept.jsonl", ProviderKind::Claude);
+        kept.cwd = Some(gone.clone());
+        kept.project_path = Some(gone.clone());
+
+        let command = ListCommand {
+            json: false,
+            jsonl: false,
+            provider: None,
+            local: false,
+            cwd: Some(root.clone()),
+            since: None,
+            after: None,
+            before: None,
+            show_deleted_projects: true,
+            limit: None,
+        };
+        let mut conversations = vec![kept];
+        apply_list_filters(&mut conversations, &command).unwrap();
+
+        assert_eq!(
+            conversations.len(),
+            1,
+            "deleted-but-under-root cwd was dropped"
+        );
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn user_block_messages_get_block_index() {
+        let entries = vec![LogEntry::User {
+            message: UserMessage {
+                role: "user".to_string(),
+                content: UserContent::Blocks(vec![
+                    ContentBlock::Text {
+                        text: "look at this".to_string(),
+                    },
+                    ContentBlock::Image {
+                        source: serde_json::json!({"type": "base64"}),
+                    },
+                ]),
+            },
+            timestamp: "2026-06-19T10:00:00-07:00".to_string(),
+            uuid: None,
+            cwd: None,
+        }];
+
+        let messages = messages_from_entries(&entries);
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, "user");
+        assert_eq!(messages[0].block_index, Some(0));
+        assert_eq!(messages[1].role, "image");
+        assert_eq!(messages[1].block_index, Some(1));
+    }
+
+    #[test]
+    fn parses_timestamp_filters() {
+        let date = parse_timestamp_filter("2026-06-20", "--after").unwrap();
+        assert_eq!(date.date_naive().to_string(), "2026-06-20");
+        assert_eq!(date.time().to_string(), "00:00:00");
+
+        let timestamp = parse_timestamp_filter("2026-06-20T12:34:56-07:00", "--before").unwrap();
+        assert_eq!(timestamp.to_rfc3339(), "2026-06-20T12:34:56-07:00");
+        assert!(parse_timestamp_filter("06/20/2026", "--after").is_err());
+    }
+
+    #[test]
+    fn list_filters_apply_time_window_and_cwd() {
+        let root =
+            std::env::temp_dir().join(format!("mnemonai-headless-filter-{}", std::process::id()));
+        let subdir = root.join("subdir");
+        let other = root.with_file_name(format!(
+            "mnemonai-headless-filter-other-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::create_dir_all(&other).unwrap();
+
+        let mut keep = conversation("keep", "/tmp/keep.jsonl", ProviderKind::Claude);
+        keep.timestamp = Local
+            .with_ymd_and_hms(2026, 6, 19, 12, 0, 0)
+            .single()
+            .unwrap();
+        keep.cwd = Some(subdir.clone());
+        keep.project_path = Some(root.clone());
+
+        let mut too_old = conversation("old", "/tmp/old.jsonl", ProviderKind::Codex);
+        too_old.timestamp = Local
+            .with_ymd_and_hms(2026, 6, 10, 12, 0, 0)
+            .single()
+            .unwrap();
+        too_old.cwd = Some(subdir.clone());
+        too_old.project_path = Some(root.clone());
+
+        let mut wrong_cwd = conversation("wrong", "/tmp/wrong.jsonl", ProviderKind::Cursor);
+        wrong_cwd.timestamp = keep.timestamp;
+        wrong_cwd.cwd = Some(other.clone());
+        wrong_cwd.project_path = Some(other.clone());
+
+        let command = ListCommand {
+            json: false,
+            jsonl: false,
+            provider: None,
+            local: false,
+            cwd: Some(root.clone()),
+            since: None,
+            after: Some("2026-06-15".to_string()),
+            before: Some("2026-06-20".to_string()),
+            show_deleted_projects: false,
+            limit: None,
+        };
+        let mut conversations = vec![keep, too_old, wrong_cwd];
+
+        apply_list_filters(&mut conversations, &command).unwrap();
+
+        assert_eq!(conversations.len(), 1);
+        assert_eq!(conversations[0].id, "keep");
+
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(other);
+    }
+
+    #[test]
+    fn status_error_heuristic_is_conservative() {
+        assert_eq!(status_is_error("failed"), Some(true));
+        assert_eq!(status_is_error("error: exit 1"), Some(true));
+        assert_eq!(status_is_error("completed"), Some(false));
+        assert_eq!(status_is_error("success"), Some(false));
+        assert_eq!(status_is_error("queued"), None);
+        assert_eq!(status_is_error("incomplete"), None);
+    }
+
+    #[test]
+    fn extracts_tool_result_exit_code_from_codex_output() {
+        let text =
+            "Chunk ID: abc\nWall time: 0.1 seconds\nProcess exited with code 101\nOutput:\nerror";
+
+        assert_eq!(tool_result_exit_code(text), Some(101));
+        assert_eq!(
+            tool_result_exit_code("Process exited with code 0\nOutput:"),
+            Some(0)
+        );
+        assert_eq!(
+            tool_result_exit_code("Output:\n1\n2\n3\n4\n5\n6\n7\n8\nProcess exited with code 1"),
+            None,
+            "only provider metadata near the top of the result should be parsed"
+        );
+    }
+
+    #[test]
+    fn merges_tool_result_error_markers_with_failure_precedence() {
+        assert_eq!(merge_error_markers(&[None, None]), None);
+        assert_eq!(merge_error_markers(&[Some(false), None]), Some(false));
+        assert_eq!(merge_error_markers(&[Some(false), Some(true)]), Some(true));
+    }
+
+    #[test]
+    fn infers_tool_result_error_from_exit_code() {
+        let entries = vec![LogEntry::Assistant {
+            message: AssistantMessage {
+                role: "assistant".to_string(),
+                content: vec![
+                    ContentBlock::ToolResult {
+                        tool_use_id: "fail".to_string(),
+                        content: Some(serde_json::Value::String(
+                            "Chunk ID: abc\nWall time: 0.1 seconds\nProcess exited with code 101\nOutput:\ncompile failed"
+                                .to_string(),
+                        )),
+                        is_error: None,
+                        status: None,
+                    },
+                    ContentBlock::ToolResult {
+                        tool_use_id: "ok".to_string(),
+                        content: Some(serde_json::Value::String(
+                            "Chunk ID: def\nWall time: 0.1 seconds\nProcess exited with code 0\nOutput:\ncompiled"
+                                .to_string(),
+                        )),
+                        is_error: None,
+                        status: None,
+                    },
+                ],
+                model: None,
+                usage: None,
+                id: None,
+            },
+            timestamp: "2026-06-19T10:00:01-07:00".to_string(),
+            uuid: None,
+        }];
+
+        let messages = messages_from_entries(&entries);
+
+        assert_eq!(messages[0].tool_result_exit_code, Some(101));
+        assert_eq!(messages[0].tool_result_error, Some(true));
+        assert_eq!(messages[1].tool_result_exit_code, Some(0));
+        assert_eq!(messages[1].tool_result_error, Some(false));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,8 +120,14 @@ fn run() -> Result<()> {
     let show_deleted_projects =
         args.show_deleted_projects || display_config.show_deleted_projects.unwrap_or(false);
 
-    // Build provider registry
-    let exclude_paths = config.exclude.unwrap_or_default();
+    // Build provider registry. Headless output must depend only on CLI flags,
+    // never the config file, so scripts/skills get stable results regardless of
+    // the user's interactive `exclude` setting.
+    let exclude_paths = if args.command.is_some() {
+        Vec::new()
+    } else {
+        config.exclude.unwrap_or_default()
+    };
     let providers: Vec<Box<dyn Provider>> = vec![
         Box::new(providers::claude::ClaudeProvider::new(exclude_paths)),
         Box::new(providers::codex::CodexProvider::new()),
@@ -130,10 +136,12 @@ fn run() -> Result<()> {
     ];
 
     if let Some(ref command) = args.command {
+        // Flags only — ignore config-derived show_last / show_deleted_projects so
+        // headless output is reproducible across differently-configured machines.
         let settings = headless::HeadlessSettings {
             cli_local: args.local,
-            show_last,
-            show_deleted_projects,
+            show_last: resolve_bool_setting(args.last, args.first, None, false),
+            show_deleted_projects: args.show_deleted_projects,
             debug: args.debug,
         };
         return headless::run_command(command, &providers, &settings);

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,6 @@ fn run() -> Result<()> {
     if let Some(ref command) = args.command {
         let settings = headless::HeadlessSettings {
             cli_local: args.local,
-            config_local: config.local.unwrap_or(false),
             show_last,
             show_deleted_projects,
             debug: args.debug,

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -623,6 +623,11 @@ fn process_tool_output_item(
         .or_else(|| item.get("result"))
         .cloned()
         .or(Some(Value::Null));
+    let status = item
+        .get("status")
+        .and_then(Value::as_str)
+        .map(ToString::to_string);
+    let is_error = item.get("is_error").and_then(Value::as_bool);
     let timestamp = timestamp_string(timestamp, state.metadata_timestamp);
 
     state.entries.push(LogEntry::User {
@@ -631,6 +636,8 @@ fn process_tool_output_item(
             content: UserContent::Blocks(vec![ContentBlock::ToolResult {
                 tool_use_id,
                 content,
+                is_error,
+                status,
             }]),
         },
         timestamp,

--- a/src/providers/cursor.rs
+++ b/src/providers/cursor.rs
@@ -1210,7 +1210,6 @@ struct Bubble {
     tool_args: Option<String>,
     tool_call_id: Option<String>,
     tool_result: Option<String>,
-    #[allow(dead_code)]
     tool_status: Option<String>,
 }
 
@@ -1467,11 +1466,18 @@ fn bubble_to_log_entry(bubble: &Bubble) -> Option<LogEntry> {
                 // Add tool result if present
                 if let Some(ref result) = bubble.tool_result {
                     let truncated = truncate_str(result, 500);
-                    content_blocks.push(serde_json::json!({
+                    let mut result_block = serde_json::json!({
                         "type": "tool_result",
                         "tool_use_id": id,
                         "content": truncated
-                    }));
+                    });
+                    if let Some(status) = &bubble.tool_status {
+                        result_block
+                            .as_object_mut()
+                            .unwrap()
+                            .insert("status".to_string(), Value::String(status.clone()));
+                    }
+                    content_blocks.push(result_block);
                 }
             }
 

--- a/src/providers/cursor_agent.rs
+++ b/src/providers/cursor_agent.rs
@@ -72,6 +72,10 @@ struct CursorAgentTranscriptBlock {
     tool_use_id: Option<String>,
     #[serde(default)]
     id: Option<String>,
+    #[serde(default)]
+    is_error: Option<bool>,
+    #[serde(default)]
+    status: Option<String>,
 }
 
 struct ParsedTranscriptLine {
@@ -697,6 +701,8 @@ fn block_to_content_block(
                 .clone()
                 .unwrap_or_else(|| format!("cursor-agent-result-{}-{}", line_idx, block_idx)),
             content: block.content.clone(),
+            is_error: block.is_error,
+            status: block.status.clone(),
         }),
         "thinking" => Some(ContentBlock::Thinking {
             thinking: block.thinking.clone().unwrap_or_default(),


### PR DESCRIPTION
## Summary
- add tool-call pairing metadata, source indices, result status/error, and exit-code fields to `show --json`
- add `list` scoping flags for retrospective analysis: `--since`, `--after`, `--before`, and `--cwd`
- make headless list/show default to global scope unless `--local` is explicitly requested

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all`
- `cargo clippy --all-targets -- -W clippy::all`
- `git diff --check`