### PR TITLE
Parse Claude tool result exit codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "mnemonai"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mnemonai"
-version = "0.12.2"
+version = "0.12.3"
 edition = "2024"
 description = "Universal AI coding conversation history browser"
 license = "MIT"

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -706,11 +706,14 @@ fn status_is_error(status: &str) -> Option<bool> {
 }
 
 fn tool_result_exit_code(text: &str) -> Option<i32> {
-    const MARKER: &str = "Process exited with code ";
+    const MARKERS: &[&str] = &["Process exited with code ", "Exit code "];
 
     text.lines().take(8).find_map(|line| {
-        let rest = line.trim().strip_prefix(MARKER)?;
-        rest.split_whitespace().next()?.parse().ok()
+        let line = line.trim();
+        MARKERS.iter().find_map(|marker| {
+            let rest = line.strip_prefix(marker)?;
+            rest.split_whitespace().next()?.parse().ok()
+        })
     })
 }
 
@@ -1296,6 +1299,23 @@ mod tests {
         );
         assert_eq!(
             tool_result_exit_code("Output:\n1\n2\n3\n4\n5\n6\n7\n8\nProcess exited with code 1"),
+            None,
+            "only provider metadata near the top of the result should be parsed"
+        );
+    }
+
+    #[test]
+    fn extracts_tool_result_exit_code_from_claude_output() {
+        assert_eq!(
+            tool_result_exit_code("Exit code 3\njq: syntax error"),
+            Some(3)
+        );
+        assert_eq!(
+            tool_result_exit_code("header\nExit code 1\nTraceback"),
+            Some(1)
+        );
+        assert_eq!(
+            tool_result_exit_code("Output:\n1\n2\n3\n4\n5\n6\n7\n8\nExit code 1"),
             None,
             "only provider metadata near the top of the result should be parsed"
         );

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -712,7 +712,12 @@ fn tool_result_exit_code(text: &str) -> Option<i32> {
         let line = line.trim();
         MARKERS.iter().find_map(|marker| {
             let rest = line.strip_prefix(marker)?;
-            rest.split_whitespace().next()?.parse().ok()
+            // Require the marker line to be exactly "<marker><integer>" with no
+            // trailing text, so prose like "Exit code 2 indicates a syntax error"
+            // is not misread as a real exit code.
+            let mut tokens = rest.split_whitespace();
+            let code = tokens.next()?.parse().ok()?;
+            tokens.next().is_none().then_some(code)
         })
     })
 }
@@ -1319,6 +1324,19 @@ mod tests {
             None,
             "only provider metadata near the top of the result should be parsed"
         );
+        assert_eq!(
+            tool_result_exit_code("Exit code 2 indicates a syntax error in the input file."),
+            None,
+            "prose that merely starts with the marker phrase must not parse as an exit code"
+        );
+        assert_eq!(
+            tool_result_exit_code("Exit code 1 (SIGHUP)"),
+            None,
+            "trailing annotations are not Claude's bare-marker format"
+        );
+        // Claude does not emit an "Exit code 0" success marker; when it does
+        // appear as a bare line it still parses (downstream treats 0 as success).
+        assert_eq!(tool_result_exit_code("Exit code 0"), Some(0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- parse Claude-style `Exit code N` markers into `tool_result_exit_code`
- keep existing Codex `Process exited with code N` parsing
- bump mnemonai to `0.12.3` so headless-capable builds are distinguishable from `0.12.2`

## Verification
- `cargo fmt --all -- --check`
- `cargo test --all`
- `cargo clippy --all-targets -- -W clippy::all`
- `cargo build`
- real Claude transcript smoke tests for normalized `tool_result_exit_code`