### PR TITLE
Scope mnemonai history to current directory tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,13 @@ curl -fsSL https://raw.githubusercontent.com/bquenin/mnemonai/main/scripts/insta
 ## Usage
 
 ```bash
-# Launch the TUI (shows all conversations across all providers)
+# Launch the TUI scoped to the current directory tree
 mnemonai
 
-# Only show conversations from the current project directory
+# Show all conversations across all providers
+mnemonai --global
+
+# Force current-directory-tree scope even when config sets local = false
 mnemonai --local
 ```
 
@@ -64,7 +67,7 @@ mnemonai list --jsonl --limit 500 | jq -r 'select(.message_count > 50) | .id'
 ```
 
 `list` and `show` accept `--provider <claude|codex|cursor|cursor-agent>`,
-`--local` (current directory only), and `--show-deleted-projects`. `list` also
+`--local` (current directory tree), and `--show-deleted-projects`. `list` also
 takes `--limit <n>`, `--since <duration>` (for example `7d`, `24h`, `2w`),
 `--after <timestamp>`, `--before <timestamp>`, and `--cwd <path>`.
 `--after`/`--before` accept RFC 3339 timestamps or `YYYY-MM-DD`; the lower bound
@@ -179,8 +182,9 @@ Press `?` at any time to open the help overlay.
 Create `~/.config/mnemonai/config.toml`:
 
 ```toml
-# Only show conversations from the current project directory
-local = false
+# Scope interactive startup to the current directory tree.
+# Unset defaults to true; set false to start globally.
+local = true
 
 # Hide projects whose name contains any of these strings
 exclude = ["some-project", "another-project"]

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -11,9 +11,6 @@ pub enum LogEntry {
         message: UserMessage,
         /// ISO 8601 timestamp when this message was sent
         timestamp: String,
-        /// UUID for linking with turn_duration entries
-        #[allow(dead_code)]
-        uuid: Option<String>,
         /// The working directory when this message was sent
         cwd: Option<String>,
     },
@@ -21,37 +18,18 @@ pub enum LogEntry {
         message: AssistantMessage,
         /// ISO 8601 timestamp when this message was sent
         timestamp: String,
-        /// UUID for linking with turn_duration entries
-        #[allow(dead_code)]
-        uuid: Option<String>,
     },
     #[serde(rename = "file-history-snapshot")]
-    #[allow(dead_code)]
-    FileHistorySnapshot {
-        #[serde(rename = "messageId")]
-        message_id: String,
-        snapshot: serde_json::Value,
-        #[serde(rename = "isSnapshotUpdate")]
-        is_snapshot_update: bool,
-    },
+    FileHistorySnapshot,
     Progress {
         data: serde_json::Value,
-        #[allow(dead_code)]
-        #[serde(flatten)]
-        extra: serde_json::Value,
     },
-    #[allow(dead_code)]
     System {
         subtype: String,
         level: Option<String>,
         /// Duration in milliseconds for turn_duration entries
         #[serde(rename = "durationMs")]
         duration_ms: Option<u64>,
-        /// Parent UUID for linking turn_duration to preceding message
-        #[serde(rename = "parentUuid")]
-        parent_uuid: Option<String>,
-        #[serde(flatten)]
-        extra: serde_json::Value,
     },
     /// Entry types this version doesn't understand (attachment, ai-title,
     /// queue-operation, ...). Newer Claude Code builds keep introducing types;
@@ -63,8 +41,6 @@ pub enum LogEntry {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct UserMessage {
-    #[allow(dead_code)]
-    pub role: String,
     pub content: UserContent,
 }
 
@@ -77,8 +53,6 @@ pub enum UserContent {
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct AssistantMessage {
-    #[allow(dead_code)]
-    pub role: String,
     pub content: Vec<ContentBlock>,
     pub model: Option<String>,
     pub usage: Option<TokenUsage>,
@@ -106,7 +80,6 @@ pub enum ContentBlock {
         text: String,
     },
     ToolUse {
-        #[allow(dead_code)]
         id: String,
         name: String,
         input: serde_json::Value,
@@ -122,10 +95,7 @@ pub enum ContentBlock {
     },
     Thinking {
         thinking: String,
-        #[allow(dead_code)]
-        signature: String,
     },
-    #[allow(dead_code)]
     Image {
         source: serde_json::Value,
     },
@@ -176,14 +146,9 @@ pub fn extract_tool_result_text(content: Option<&serde_json::Value>) -> Option<S
 /// Agent progress data from subagent conversations
 #[derive(Debug, Deserialize, Clone)]
 pub struct AgentProgressData {
-    #[allow(dead_code)]
-    #[serde(rename = "type")]
-    pub progress_type: String,
     #[serde(rename = "agentId")]
     pub agent_id: String,
     pub message: AgentMessage,
-    #[allow(dead_code)]
-    pub prompt: Option<String>,
 }
 
 /// Individual message within an agent conversation
@@ -197,8 +162,6 @@ pub struct AgentMessage {
 /// Content of an agent message (mirrors UserMessage/AssistantMessage structure)
 #[derive(Debug, Deserialize, Clone)]
 pub struct AgentMessageContent {
-    #[allow(dead_code)]
-    pub role: String,
     pub content: AgentContent,
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -119,13 +119,21 @@ pub struct Args {
     )]
     pub debug: Option<DebugLevel>,
 
-    /// Only show conversations from the current project directory
+    /// Only show conversations from the current directory tree
     #[arg(
         long,
         short = 'L',
-        help = "Only show conversations from the current project directory"
+        help = "Only show conversations from the current directory tree"
     )]
     pub local: bool,
+
+    /// Show all conversations, ignoring the current directory tree scope
+    #[arg(
+        long,
+        conflicts_with = "local",
+        help = "Show all conversations, ignoring the current directory tree scope"
+    )]
+    pub global: bool,
 
     /// Include conversations from deleted project directories
     #[arg(long, help = "Include conversations from deleted project directories")]
@@ -159,7 +167,7 @@ pub struct Args {
     #[arg(
         value_name = "FILE",
         help = "JSONL conversation file to view directly",
-        conflicts_with_all = ["local", "show_dir", "resume", "show_path", "show_id", "plain", "render"]
+        conflicts_with_all = ["local", "global", "show_dir", "resume", "show_path", "show_id", "plain", "render"]
     )]
     pub input_file: Option<PathBuf>,
 }
@@ -207,7 +215,7 @@ pub struct ListCommand {
     #[arg(long, value_enum)]
     pub provider: Option<ProviderFilter>,
 
-    /// Only include conversations from the current project directory
+    /// Only include conversations from the current directory tree
     #[arg(long)]
     pub local: bool,
 
@@ -249,7 +257,7 @@ pub struct ShowCommand {
     #[arg(long, value_enum)]
     pub provider: Option<ProviderFilter>,
 
-    /// Only search conversations from the current project directory
+    /// Only search conversations from the current directory tree
     #[arg(long)]
     pub local: bool,
 
@@ -297,5 +305,20 @@ mod tests {
 
         assert!(args.command.is_none());
         assert_eq!(args.input_file, Some(PathBuf::from("session.jsonl")));
+    }
+
+    #[test]
+    fn parses_global_interactive_flag() {
+        let args = Args::try_parse_from(["mnemonai", "--global"]).unwrap();
+
+        assert!(args.global);
+        assert!(!args.local);
+    }
+
+    #[test]
+    fn global_conflicts_with_local() {
+        let result = Args::try_parse_from(["mnemonai", "--global", "--local"]);
+
+        assert!(result.is_err());
     }
 }

--- a/src/display.rs
+++ b/src/display.rs
@@ -547,7 +547,7 @@ fn process_entry<F: OutputFormatter>(
 ) {
     match entry {
         LogEntry::Summary { .. }
-        | LogEntry::FileHistorySnapshot { .. }
+        | LogEntry::FileHistorySnapshot
         | LogEntry::System { .. }
         | LogEntry::Unknown => {
             // Skip metadata entries

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Duration, Local, NaiveDate, TimeZone};
 use serde::Serialize;
 use serde_json::Value;
 use std::io::Write;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 pub struct HeadlessSettings {
     pub cli_local: bool,
@@ -283,14 +283,18 @@ fn apply_list_filters(conversations: &mut Vec<Conversation>, command: &ListComma
         .as_deref()
         .map(|value| parse_timestamp_filter(value, "--before"))
         .transpose()?;
-    let cwd_roots = command.cwd.as_deref().map(filter_path_roots).transpose()?;
+    let cwd_roots = command
+        .cwd
+        .as_deref()
+        .map(crate::loader::filter_path_roots)
+        .transpose()?;
 
     conversations.retain(|conversation| {
         after.is_none_or(|after| conversation.timestamp >= after)
             && before.is_none_or(|before| conversation.timestamp < before)
             && cwd_roots
                 .as_ref()
-                .is_none_or(|roots| conversation_matches_cwd(conversation, roots))
+                .is_none_or(|roots| crate::loader::conversation_matches_scope(conversation, roots))
     });
 
     Ok(())
@@ -372,45 +376,6 @@ fn invalid_timestamp(value: &str, flag: &str) -> AppError {
         "Invalid {} value '{}'; expected RFC 3339 or YYYY-MM-DD",
         flag, value
     ))
-}
-
-/// Candidate root forms for a `--cwd` filter: the absolutized literal path and,
-/// when it resolves, its canonical (symlink-resolved) form. A conversation path
-/// is matched against both because a recorded cwd that no longer exists on disk
-/// can't be canonicalized, so it would otherwise fail to match a canonical root
-/// even when it is genuinely under the path (e.g. `/tmp` vs `/private/tmp`).
-fn filter_path_roots(path: &Path) -> Result<Vec<PathBuf>> {
-    let absolute = if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        std::env::current_dir()?.join(path)
-    };
-
-    let mut roots = Vec::with_capacity(2);
-    if let Ok(canonical) = absolute.canonicalize()
-        && canonical != absolute
-    {
-        roots.push(canonical);
-    }
-    roots.push(absolute);
-    Ok(roots)
-}
-
-fn conversation_matches_cwd(conversation: &Conversation, roots: &[PathBuf]) -> bool {
-    conversation
-        .cwd
-        .as_ref()
-        .into_iter()
-        .chain(conversation.project_path.as_ref())
-        .any(|path| path_at_or_under(path, roots))
-}
-
-fn path_at_or_under(path: &Path, roots: &[PathBuf]) -> bool {
-    let canonical = path.canonicalize();
-    let candidates = canonical.iter().map(PathBuf::as_path).chain([path]);
-    candidates
-        .into_iter()
-        .any(|candidate| roots.iter().any(|root| candidate.starts_with(root)))
 }
 
 fn reindex_conversations(conversations: &mut [Conversation]) {

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -539,7 +539,7 @@ fn messages_from_entries(entries: &[LogEntry]) -> Vec<MessageDto> {
                 message.duration_ms = *duration_ms;
                 push_message(&mut messages, message);
             }
-            LogEntry::FileHistorySnapshot { .. } | LogEntry::Unknown => {}
+            LogEntry::FileHistorySnapshot | LogEntry::Unknown => {}
         }
     }
     messages
@@ -782,16 +782,13 @@ mod tests {
         let entries = vec![
             LogEntry::User {
                 message: UserMessage {
-                    role: "user".to_string(),
                     content: UserContent::String("run tests".to_string()),
                 },
                 timestamp: "2026-06-19T10:00:00-07:00".to_string(),
-                uuid: None,
                 cwd: None,
             },
             LogEntry::Assistant {
                 message: AssistantMessage {
-                    role: "assistant".to_string(),
                     content: vec![
                         ContentBlock::Text {
                             text: "I'll run them.".to_string(),
@@ -803,7 +800,6 @@ mod tests {
                         },
                         ContentBlock::Thinking {
                             thinking: "Need to verify failures.".to_string(),
-                            signature: "sig".to_string(),
                         },
                     ],
                     model: Some("claude-test".to_string()),
@@ -811,7 +807,6 @@ mod tests {
                     id: None,
                 },
                 timestamp: "2026-06-19T10:00:01-07:00".to_string(),
-                uuid: None,
             },
         ];
 
@@ -915,16 +910,13 @@ mod tests {
             // Blank user text is dropped rather than emitted as an empty message.
             LogEntry::User {
                 message: UserMessage {
-                    role: "user".to_string(),
                     content: UserContent::String("   ".to_string()),
                 },
                 timestamp: "2026-06-19T10:00:00-07:00".to_string(),
-                uuid: None,
                 cwd: None,
             },
             LogEntry::Assistant {
                 message: AssistantMessage {
-                    role: "assistant".to_string(),
                     content: vec![
                         ContentBlock::ToolResult {
                             tool_use_id: "t1".to_string(),
@@ -944,14 +936,11 @@ mod tests {
                     id: None,
                 },
                 timestamp: "2026-06-19T10:00:01-07:00".to_string(),
-                uuid: None,
             },
             LogEntry::System {
                 subtype: "turn_duration".to_string(),
                 level: Some("warning".to_string()),
                 duration_ms: Some(1234),
-                parent_uuid: None,
-                extra: serde_json::Value::Null,
             },
         ];
 
@@ -1128,7 +1117,6 @@ mod tests {
     fn user_block_messages_get_block_index() {
         let entries = vec![LogEntry::User {
             message: UserMessage {
-                role: "user".to_string(),
                 content: UserContent::Blocks(vec![
                     ContentBlock::Text {
                         text: "look at this".to_string(),
@@ -1139,7 +1127,6 @@ mod tests {
                 ]),
             },
             timestamp: "2026-06-19T10:00:00-07:00".to_string(),
-            uuid: None,
             cwd: None,
         }];
 
@@ -1315,7 +1302,6 @@ mod tests {
     fn infers_tool_result_error_from_exit_code() {
         let entries = vec![LogEntry::Assistant {
             message: AssistantMessage {
-                role: "assistant".to_string(),
                 content: vec![
                     ContentBlock::ToolResult {
                         tool_use_id: "fail".to_string(),
@@ -1341,7 +1327,6 @@ mod tests {
                 id: None,
             },
             timestamp: "2026-06-19T10:00:01-07:00".to_string(),
-            uuid: None,
         }];
 
         let messages = messages_from_entries(&entries);

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -16,6 +16,7 @@ use std::path::Path;
 
 pub struct HeadlessSettings {
     pub cli_local: bool,
+    pub cli_global: bool,
     pub show_last: bool,
     pub show_deleted_projects: bool,
     pub debug: Option<DebugLevel>,
@@ -273,7 +274,11 @@ fn use_local_scope(settings: &HeadlessSettings, command_local: bool, force_globa
     // Headless commands default to global output even when the interactive TUI
     // config has `local = true`; scripts and skills need stable scope unless the
     // caller explicitly passes --local.
-    !force_global && (command_local || settings.cli_local)
+    //
+    // An explicit `--global` (cli_global) — like `--cwd`'s force_global, which
+    // loads everything before filtering by path — overrides any --local request,
+    // so `mnemonai --global list --local` returns global results as the flag promises.
+    !force_global && !settings.cli_global && (command_local || settings.cli_local)
 }
 
 fn apply_list_filters(conversations: &mut Vec<Conversation>, command: &ListCommand) -> Result<()> {
@@ -1210,6 +1215,7 @@ mod tests {
     fn headless_scope_is_global_without_explicit_local_flag() {
         let settings = HeadlessSettings {
             cli_local: false,
+            cli_global: false,
             show_last: false,
             show_deleted_projects: false,
             debug: None,
@@ -1223,6 +1229,7 @@ mod tests {
 
         let cli_settings = HeadlessSettings {
             cli_local: true,
+            cli_global: false,
             show_last: false,
             show_deleted_projects: false,
             debug: None,
@@ -1232,6 +1239,25 @@ mod tests {
             !use_local_scope(&cli_settings, true, true),
             "--cwd must force global loading before cwd filtering"
         );
+    }
+
+    #[test]
+    fn global_flag_forces_global_scope_over_local() {
+        // `--global` must override a subcommand `--local` so the flag's promise to
+        // ignore directory scoping holds for `mnemonai --global list --local`.
+        let settings = HeadlessSettings {
+            cli_local: false,
+            cli_global: true,
+            show_last: false,
+            show_deleted_projects: false,
+            debug: None,
+        };
+
+        assert!(
+            !use_local_scope(&settings, true, false),
+            "--global must win over a subcommand --local"
+        );
+        assert!(!use_local_scope(&settings, false, false));
     }
 
     #[test]

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -39,7 +39,6 @@ impl ConversationLoad {
 }
 
 /// Load conversations from ALL projects globally
-#[allow(dead_code)]
 pub fn load_all_conversations(
     show_last: bool,
     debug_level: Option<DebugLevel>,
@@ -319,6 +318,7 @@ pub fn list_projects(root: &Path, exclude_names: &[String]) -> Result<Vec<Projec
 }
 
 /// Find and process all conversation files in one pass
+#[allow(dead_code)]
 pub fn load_conversations(
     projects_dir: &Path,
     show_last: bool,

--- a/src/history/loader.rs
+++ b/src/history/loader.rs
@@ -317,24 +317,6 @@ pub fn list_projects(root: &Path, exclude_names: &[String]) -> Result<Vec<Projec
     Ok(projects)
 }
 
-/// Find and process all conversation files in one pass
-#[allow(dead_code)]
-pub fn load_conversations(
-    projects_dir: &Path,
-    show_last: bool,
-    debug_level: Option<DebugLevel>,
-) -> Result<Vec<Conversation>> {
-    let cache = Mutex::new(load_provider_cache(ProviderKind::Claude, show_last));
-    let (conversations, fresh) =
-        load_conversations_with_cache(projects_dir, show_last, debug_level, &cache)?;
-    save_conversations(
-        ProviderKind::Claude,
-        show_last,
-        fresh.iter().map(|(conv, fingerprint)| (conv, *fingerprint)),
-    );
-    Ok(conversations)
-}
-
 /// Conversations loaded from one project, paired with the freshly parsed
 /// (cache-miss) ones the caller should persist in a single batch.
 type ProjectLoad = (Vec<Conversation>, Vec<(Conversation, SourceFingerprint)>);

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -22,7 +22,7 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 
 // Re-export public API
-pub use loader::{load_all_conversations_streaming, load_conversations};
+pub use loader::{load_all_conversations, load_all_conversations_streaming};
 pub use parser::process_conversation_file;
 pub use path::{
     convert_path_to_project_dir_name, format_short_name_from_path, path_to_string,

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -3,8 +3,11 @@
 
 use crate::cli::{DebugLevel, ProviderFilter};
 use crate::error::{AppError, Result};
-use crate::history::{Conversation, ProviderKind};
+use crate::history::{Conversation, LoaderMessage, ProviderKind};
 use crate::providers::Provider;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
 
 /// Whether a provider should be included given an optional provider filter.
 /// `None` matches every provider.
@@ -12,12 +15,12 @@ pub fn provider_filter_matches(filter: Option<ProviderFilter>, kind: &ProviderKi
     filter.is_none_or(|filter| &filter.kind() == kind)
 }
 
-/// Load conversations scoped to the current directory across all providers.
+/// Load conversations scoped to the current directory tree across all providers.
 ///
-/// Mirrors the TUI's local-mode loading: non-Claude providers are filtered to
-/// the current directory, while Claude's loader is already directory-scoped.
-/// Providers that fail to load are silently skipped. The result is unsorted and
-/// unindexed; callers sort by timestamp and assign display indexes.
+/// The scope is inclusive: a conversation whose recorded cwd or project path is
+/// the current directory or any descendant is included. Providers that fail to
+/// load are silently skipped. The result is unsorted and unindexed; callers sort
+/// by timestamp and assign display indexes.
 pub fn load_local(
     providers: &[Box<dyn Provider>],
     show_last: bool,
@@ -31,6 +34,18 @@ pub fn load_local(
         ))
     })?;
 
+    let roots = filter_path_roots(&current_dir)?;
+    load_scoped(providers, show_last, debug, provider_filter, &roots)
+}
+
+/// Load conversations scoped to explicit root candidates.
+pub fn load_scoped(
+    providers: &[Box<dyn Provider>],
+    show_last: bool,
+    debug: Option<DebugLevel>,
+    provider_filter: Option<ProviderFilter>,
+    roots: &[PathBuf],
+) -> Result<Vec<Conversation>> {
     let mut conversations = Vec::new();
     for provider in providers {
         if !provider_filter_matches(provider_filter, &provider.kind()) {
@@ -38,15 +53,7 @@ pub fn load_local(
         }
 
         if let Ok(mut provider_conversations) = provider.load_conversations(show_last, debug) {
-            // For non-Claude providers, filter to the current directory.
-            if provider.kind() != ProviderKind::Claude {
-                provider_conversations.retain(|conversation| {
-                    conversation
-                        .project_path
-                        .as_ref()
-                        .is_some_and(|path| path == &current_dir)
-                });
-            }
+            retain_conversations_in_scope(&mut provider_conversations, roots);
             conversations.extend(provider_conversations);
         }
     }
@@ -54,9 +61,103 @@ pub fn load_local(
     Ok(conversations)
 }
 
+/// Candidate root forms for a cwd filter: the absolutized literal path and,
+/// when it resolves, its canonical (symlink-resolved) form. A conversation path
+/// is matched against both because a recorded cwd that no longer exists on disk
+/// can't be canonicalized, so it would otherwise fail to match a canonical root
+/// even when it is genuinely under the path (e.g. `/tmp` vs `/private/tmp`).
+pub fn filter_path_roots(path: &Path) -> Result<Vec<PathBuf>> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()?.join(path)
+    };
+
+    let mut roots = Vec::with_capacity(2);
+    if let Ok(canonical) = absolute.canonicalize()
+        && canonical != absolute
+    {
+        roots.push(canonical);
+    }
+    roots.push(absolute);
+    Ok(roots)
+}
+
+pub fn retain_conversations_in_scope(conversations: &mut Vec<Conversation>, roots: &[PathBuf]) {
+    conversations.retain(|conversation| conversation_matches_scope(conversation, roots));
+}
+
+pub fn filter_loader_messages(
+    rx: Receiver<LoaderMessage>,
+    roots: Vec<PathBuf>,
+) -> Receiver<LoaderMessage> {
+    let (tx, filtered_rx) = mpsc::channel();
+    thread::spawn(move || {
+        for message in rx {
+            match message {
+                LoaderMessage::Batch(mut batch) => {
+                    retain_conversations_in_scope(&mut batch, &roots);
+                    if !batch.is_empty() {
+                        let _ = tx.send(LoaderMessage::Batch(batch));
+                    }
+                }
+                other => {
+                    let done = matches!(other, LoaderMessage::Done | LoaderMessage::Fatal(_));
+                    let _ = tx.send(other);
+                    if done {
+                        break;
+                    }
+                }
+            }
+        }
+    });
+    filtered_rx
+}
+
+pub fn conversation_matches_scope(conversation: &Conversation, roots: &[PathBuf]) -> bool {
+    conversation
+        .cwd
+        .as_ref()
+        .into_iter()
+        .chain(conversation.project_path.as_ref())
+        .any(|path| path_at_or_under(path, roots))
+}
+
+fn path_at_or_under(path: &Path, roots: &[PathBuf]) -> bool {
+    let canonical = path.canonicalize();
+    let candidates = canonical.iter().map(PathBuf::as_path).chain([path]);
+    candidates
+        .into_iter()
+        .any(|candidate| roots.iter().any(|root| candidate.starts_with(root)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::{Local, TimeZone};
+
+    fn conversation(id: &str, cwd: Option<PathBuf>, project_path: Option<PathBuf>) -> Conversation {
+        Conversation {
+            path: PathBuf::from(format!("/tmp/{id}.jsonl")),
+            index: 0,
+            provider: ProviderKind::Codex,
+            id: id.to_string(),
+            timestamp: Local.timestamp_opt(1_700_000_000, 0).single().unwrap(),
+            preview: "preview".to_string(),
+            full_text: "full text".to_string(),
+            project_name: Some("project".to_string()),
+            project_path,
+            cwd,
+            message_count: 1,
+            parse_errors: Vec::new(),
+            summary: None,
+            model: None,
+            total_tokens: 0,
+            duration_minutes: None,
+            search_text_lower: None,
+            search_topic_end: None,
+        }
+    }
 
     #[test]
     fn provider_filter_matches_expected_kinds() {
@@ -73,5 +174,57 @@ mod tests {
             Some(ProviderFilter::CursorAgent),
             &ProviderKind::CursorAgent
         ));
+    }
+
+    #[test]
+    fn scope_matching_includes_root_and_descendants() {
+        let root =
+            std::env::temp_dir().join(format!("mnemonai-loader-scope-{}", std::process::id()));
+        let subdir = root.join("qube/bquenin/mnemonai");
+        let other = root.with_file_name(format!(
+            "mnemonai-loader-scope-other-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&subdir).unwrap();
+        std::fs::create_dir_all(&other).unwrap();
+
+        let roots = filter_path_roots(&root).unwrap();
+        assert!(conversation_matches_scope(
+            &conversation("at-root", Some(root.clone()), None),
+            &roots
+        ));
+        assert!(conversation_matches_scope(
+            &conversation("nested", Some(subdir.clone()), None),
+            &roots
+        ));
+        assert!(conversation_matches_scope(
+            &conversation("project-path", None, Some(subdir)),
+            &roots
+        ));
+        assert!(!conversation_matches_scope(
+            &conversation("outside", Some(other.clone()), Some(other.clone())),
+            &roots
+        ));
+
+        let _ = std::fs::remove_dir_all(root);
+        let _ = std::fs::remove_dir_all(other);
+    }
+
+    #[test]
+    fn scope_matching_keeps_deleted_descendant_paths() {
+        let root = std::env::temp_dir().join(format!(
+            "mnemonai-loader-deleted-scope-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        let gone = root.join("repo/.worktrees/feature");
+        let roots = filter_path_roots(&root).unwrap();
+
+        assert!(conversation_matches_scope(
+            &conversation("gone", Some(gone.clone()), Some(gone)),
+            &roots
+        ));
+
+        let _ = std::fs::remove_dir_all(root);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,6 +148,7 @@ fn run() -> Result<()> {
         // headless output is reproducible across differently-configured machines.
         let settings = headless::HeadlessSettings {
             cli_local: args.local,
+            cli_global: args.global,
             show_last: resolve_bool_setting(args.last, args.first, None, false),
             show_deleted_projects: args.show_deleted_projects,
             debug: args.debug,

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,15 @@ fn run() -> Result<()> {
         display_config.pager,
         std::io::stdout().is_terminal(),
     );
-    let use_global = !args.local && !config.local.unwrap_or(false);
+    let use_global = if args.global {
+        true
+    } else if args.local {
+        false
+    } else {
+        // New interactive default: scope to the current directory tree. An
+        // explicit `local = false` config keeps the previous global startup.
+        config.local == Some(false)
+    };
     let show_deleted_projects =
         args.show_deleted_projects || display_config.show_deleted_projects.unwrap_or(false);
 
@@ -238,34 +246,31 @@ fn run() -> Result<()> {
             (tui::Action::Delete(_), _) => unreachable!("Delete is handled internally"),
         }
     } else {
-        // Local mode - load from all providers for current directory
-        let mut conversations = loader::load_local(&providers, show_last, args.debug, None)?;
+        // Current-directory-tree mode - merge streaming loaders, then filter
+        // batches before they enter the TUI.
+        let current_dir = std::env::current_dir()?;
+        let scope_roots = loader::filter_path_roots(&current_dir)?;
+        let receivers: Vec<_> = providers
+            .iter()
+            .map(|p| p.load_conversations_streaming(show_last, args.debug))
+            .collect();
+        let rx = loader::filter_loader_messages(merge_streaming_loaders(receivers), scope_roots);
 
-        // Sort merged conversations by timestamp (newest first) and re-index
-        conversations.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
-        for (idx, conv) in conversations.iter_mut().enumerate() {
-            conv.index = idx;
-        }
-
-        if conversations.is_empty() {
-            return Err(AppError::NoHistoryFound("selected scope".to_string()));
-        }
-
-        match tui::run(
-            conversations.clone(),
+        match tui::run_with_loader(
+            rx,
             use_relative_time,
             tool_display,
             show_thinking,
             show_deleted_projects,
             &providers,
         )? {
-            tui::Action::Select(path) => (conversations, path),
-            tui::Action::Resume(path) => {
-                resume_conversation(&conversations, &path, &providers, default_args)?;
+            (tui::Action::Select(path), convs) => (convs, path),
+            (tui::Action::Resume(path), convs) => {
+                resume_conversation(&convs, &path, &providers, default_args)?;
                 return Ok(());
             }
-            tui::Action::Quit => return Err(AppError::SelectionCancelled),
-            tui::Action::Delete(_) => unreachable!("Delete is handled internally"),
+            (tui::Action::Quit, _) => return Err(AppError::SelectionCancelled),
+            (tui::Action::Delete(_), _) => unreachable!("Delete is handled internally"),
         }
     };
 

--- a/src/providers/claude.rs
+++ b/src/providers/claude.rs
@@ -7,16 +7,12 @@ use std::process::Command;
 use std::sync::mpsc::Receiver;
 
 pub struct ClaudeProvider {
-    current_dir: Option<std::path::PathBuf>,
     exclude_paths: Vec<String>,
 }
 
 impl ClaudeProvider {
     pub fn new(exclude_paths: Vec<String>) -> Self {
-        Self {
-            current_dir: std::env::current_dir().ok(),
-            exclude_paths,
-        }
+        Self { exclude_paths }
     }
 }
 
@@ -41,17 +37,7 @@ impl super::Provider for ClaudeProvider {
         show_last: bool,
         debug: Option<crate::cli::DebugLevel>,
     ) -> Result<Vec<Conversation>> {
-        let current_dir = self.current_dir.as_ref().ok_or_else(|| {
-            AppError::Io(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "Failed to get current directory",
-            ))
-        })?;
-        let projects_dir = history::get_claude_projects_dir(current_dir)?;
-        if !projects_dir.exists() {
-            return Ok(Vec::new());
-        }
-        history::load_conversations(&projects_dir, show_last, debug)
+        history::load_all_conversations(show_last, debug, &self.exclude_paths)
     }
 
     fn load_conversations_streaming(

--- a/src/providers/claude.rs
+++ b/src/providers/claude.rs
@@ -25,13 +25,6 @@ impl super::Provider for ClaudeProvider {
         "Claude Code"
     }
 
-    fn detect(&self) -> bool {
-        // Claude is always available if ~/.claude/projects exists
-        history::get_claude_projects_root()
-            .map(|p| p.exists())
-            .unwrap_or(false)
-    }
-
     fn load_conversations(
         &self,
         show_last: bool,

--- a/src/providers/codex.rs
+++ b/src/providers/codex.rs
@@ -182,10 +182,6 @@ impl super::Provider for CodexProvider {
         "Codex"
     }
 
-    fn detect(&self) -> bool {
-        self.sessions_root().is_some_and(|root| root.exists())
-    }
-
     fn load_conversations(
         &self,
         show_last: bool,
@@ -401,7 +397,7 @@ fn process_codex_record(state: &mut CodexParseState, record: &Value, line_idx: u
         Some("function_call_output") | Some("custom_tool_call_output") => {
             process_tool_output_item(state, item, timestamp, line_idx)
         }
-        Some("reasoning") => process_reasoning_item(state, item, timestamp, line_idx),
+        Some("reasoning") => process_reasoning_item(state, item, timestamp),
         Some("token_count") => parse_token_count(state, item),
         _ => {}
     }
@@ -496,11 +492,9 @@ fn process_message_item(
     match role {
         "user" => state.entries.push(LogEntry::User {
             message: UserMessage {
-                role: "user".to_string(),
                 content: UserContent::Blocks(blocks),
             },
             timestamp,
-            uuid,
             cwd: state
                 .cwd
                 .as_ref()
@@ -508,14 +502,12 @@ fn process_message_item(
         }),
         "assistant" => state.entries.push(LogEntry::Assistant {
             message: AssistantMessage {
-                role: "assistant".to_string(),
                 content: blocks,
                 model: state.model.clone(),
                 usage: None,
                 id: uuid,
             },
             timestamp,
-            uuid: None,
         }),
         _ => {}
     }
@@ -595,14 +587,12 @@ fn push_tool_call_entry(
 
     state.entries.push(LogEntry::Assistant {
         message: AssistantMessage {
-            role: "assistant".to_string(),
             content: vec![ContentBlock::ToolUse { id, name, input }],
             model: state.model.clone(),
             usage: None,
             id: None,
         },
         timestamp,
-        uuid: None,
     });
 }
 
@@ -632,7 +622,6 @@ fn process_tool_output_item(
 
     state.entries.push(LogEntry::User {
         message: UserMessage {
-            role: "user".to_string(),
             content: UserContent::Blocks(vec![ContentBlock::ToolResult {
                 tool_use_id,
                 content,
@@ -641,7 +630,6 @@ fn process_tool_output_item(
             }]),
         },
         timestamp,
-        uuid: None,
         cwd: state
             .cwd
             .as_ref()
@@ -653,7 +641,6 @@ fn process_reasoning_item(
     state: &mut CodexParseState,
     item: &Value,
     timestamp: Option<DateTime<FixedOffset>>,
-    line_idx: usize,
 ) {
     let Some(summary) = item
         .get("summary")
@@ -666,17 +653,12 @@ fn process_reasoning_item(
 
     state.entries.push(LogEntry::Assistant {
         message: AssistantMessage {
-            role: "assistant".to_string(),
-            content: vec![ContentBlock::Thinking {
-                thinking: summary,
-                signature: format!("codex-thinking-{}", line_idx),
-            }],
+            content: vec![ContentBlock::Thinking { thinking: summary }],
             model: state.model.clone(),
             usage: None,
             id: None,
         },
         timestamp,
-        uuid: None,
     });
 }
 

--- a/src/providers/cursor.rs
+++ b/src/providers/cursor.rs
@@ -874,10 +874,6 @@ impl super::Provider for CursorProvider {
         "Cursor (IDE)"
     }
 
-    fn detect(&self) -> bool {
-        self.global_db_path.exists()
-    }
-
     fn load_conversations(
         &self,
         show_last: bool,

--- a/src/providers/cursor_agent.rs
+++ b/src/providers/cursor_agent.rs
@@ -63,8 +63,6 @@ struct CursorAgentTranscriptBlock {
     #[serde(default)]
     thinking: Option<String>,
     #[serde(default)]
-    signature: Option<String>,
-    #[serde(default)]
     source: Option<Value>,
     #[serde(default)]
     content: Option<Value>,
@@ -270,10 +268,6 @@ impl super::Provider for CursorAgentProvider {
 
     fn name(&self) -> &str {
         "Cursor Agent CLI"
-    }
-
-    fn detect(&self) -> bool {
-        self.projects_root.exists()
     }
 
     fn load_conversations(
@@ -639,23 +633,19 @@ fn parse_transcript_line(
     let entry = match role.as_str() {
         "user" => LogEntry::User {
             message: UserMessage {
-                role: "user".to_string(),
                 content: UserContent::Blocks(blocks),
             },
             timestamp: timestamp_str,
-            uuid: None,
             cwd: workspace_path.map(|path| path.to_string_lossy().to_string()),
         },
         "assistant" => LogEntry::Assistant {
             message: AssistantMessage {
-                role: "assistant".to_string(),
                 content: blocks,
                 model: None,
                 usage: None,
                 id: None,
             },
             timestamp: timestamp_str,
-            uuid: None,
         },
         _ => return Ok(None),
     };
@@ -706,10 +696,6 @@ fn block_to_content_block(
         }),
         "thinking" => Some(ContentBlock::Thinking {
             thinking: block.thinking.clone().unwrap_or_default(),
-            signature: block
-                .signature
-                .clone()
-                .unwrap_or_else(|| format!("cursor-agent-thinking-{}-{}", line_idx, block_idx)),
         }),
         "image" => block.source.as_ref().map(|source| ContentBlock::Image {
             source: source.clone(),

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -8,11 +8,9 @@ use crate::error::Result;
 use crate::history::{Conversation, LoaderMessage, ProviderKind};
 use std::sync::mpsc::Receiver;
 
-#[allow(dead_code)]
 pub trait Provider: Send + Sync {
     fn kind(&self) -> ProviderKind;
     fn name(&self) -> &str;
-    fn detect(&self) -> bool;
 
     /// Load conversations (synchronous, for single-project mode)
     fn load_conversations(

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -175,48 +175,6 @@ pub struct App {
 }
 
 impl App {
-    /// Create a new app with all conversations pre-loaded (existing behavior)
-    #[allow(dead_code)]
-    pub fn new(
-        mut conversations: Vec<Conversation>,
-        use_relative_time: bool,
-        tool_display: ToolDisplayMode,
-        show_thinking: bool,
-        show_deleted_projects: bool,
-    ) -> Self {
-        if !show_deleted_projects {
-            conversations.retain(|c| {
-                c.project_path
-                    .as_ref()
-                    .is_none_or(|p| project_path_is_live(p))
-            });
-        }
-        let searchable = search::precompute_search_text(&mut conversations);
-        let filtered: Vec<usize> = (0..conversations.len()).collect();
-        let selected = if filtered.is_empty() { None } else { Some(0) };
-
-        Self {
-            conversations,
-            searchable,
-            filtered,
-            selected,
-            query: String::new(),
-            query_words: Vec::new(),
-            cursor_pos: 0,
-            use_relative_time,
-            loading_state: LoadingState::Ready,
-            dialog_mode: DialogMode::None,
-            app_mode: AppMode::List,
-            status_message: None,
-            tool_display,
-            show_thinking,
-            show_timing: false,
-            single_file_mode: false,
-            previous_query: String::new(),
-            show_deleted_projects,
-        }
-    }
-
     /// Create a new app in loading state
     pub fn new_loading(
         use_relative_time: bool,
@@ -1878,6 +1836,33 @@ mod tests {
         }
     }
 
+    fn app_with_conversations(mut conversations: Vec<Conversation>) -> App {
+        let searchable = search::precompute_search_text(&mut conversations);
+        let filtered: Vec<usize> = (0..conversations.len()).collect();
+        let selected = if filtered.is_empty() { None } else { Some(0) };
+
+        App {
+            conversations,
+            searchable,
+            filtered,
+            selected,
+            query: String::new(),
+            query_words: Vec::new(),
+            cursor_pos: 0,
+            use_relative_time: false,
+            loading_state: LoadingState::Ready,
+            dialog_mode: DialogMode::None,
+            app_mode: AppMode::List,
+            status_message: None,
+            tool_display: ToolDisplayMode::Hidden,
+            show_thinking: false,
+            show_timing: false,
+            single_file_mode: false,
+            previous_query: String::new(),
+            show_deleted_projects: true,
+        }
+    }
+
     /// Typing a query one keystroke at a time must find the same conversations
     /// as entering it at once. The narrow-on-extend optimization used to narrow
     /// from the `"auth "` state, whose trailing term is whole-word constrained —
@@ -1889,7 +1874,7 @@ mod tests {
             make_conv("authentication flow setup", 0),
             make_conv("auth flow setup", 1),
         ];
-        let mut app = App::new(convs, false, ToolDisplayMode::Hidden, false, true);
+        let mut app = app_with_conversations(convs);
 
         type_query(&mut app, "auth flow");
 
@@ -1910,7 +1895,7 @@ mod tests {
             make_conv("authentication flow setup", 0),
             make_conv("auth flow setup", 1),
         ];
-        let mut app = App::new(convs, false, ToolDisplayMode::Hidden, false, true);
+        let mut app = app_with_conversations(convs);
 
         type_query(&mut app, "auth ");
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -176,6 +176,7 @@ pub struct App {
 
 impl App {
     /// Create a new app with all conversations pre-loaded (existing behavior)
+    #[allow(dead_code)]
     pub fn new(
         mut conversations: Vec<Conversation>,
         use_relative_time: bool,
@@ -1669,104 +1670,6 @@ impl Drop for TerminalGuard {
 /// Name column width for ledger-style display
 const NAME_WIDTH: usize = 9;
 
-/// Run the TUI and return the selected conversation path or None if cancelled
-pub fn run(
-    conversations: Vec<Conversation>,
-    use_relative_time: bool,
-    tool_display: ToolDisplayMode,
-    show_thinking: bool,
-    show_deleted_projects: bool,
-    providers: &[Box<dyn Provider>],
-) -> Result<Action> {
-    // Set up panic hook to restore terminal
-    let original_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |panic_info| {
-        let _ = terminal::disable_raw_mode();
-        let _ = crossterm::execute!(io::stdout(), LeaveAlternateScreen);
-        original_hook(panic_info);
-    }));
-
-    let mut guard = TerminalGuard::new()?;
-    let mut app = App::new(
-        conversations,
-        use_relative_time,
-        tool_display,
-        show_thinking,
-        show_deleted_projects,
-    );
-
-    loop {
-        let frame_area = guard.terminal.get_frame().area();
-        let viewport_height = frame_area.height.saturating_sub(3) as usize; // Subtract header/status
-        let content_width = (frame_area.width as usize).saturating_sub(NAME_WIDTH + 3);
-
-        // Check for resize in view mode
-        app.check_view_resize(content_width, viewport_height, providers);
-
-        guard.terminal.draw(|frame| ui::render(frame, &app))?;
-
-        if let Event::Key(key) = event::read().map_err(|e| AppError::Io(io::Error::other(e)))? {
-            // Only handle key press events (not release)
-            if key.kind == KeyEventKind::Press {
-                // Check for Enter in list mode - enter view mode (but not during dialogs)
-                if matches!(app.app_mode(), AppMode::List)
-                    && *app.dialog_mode() == DialogMode::None
-                    && key.code == KeyCode::Enter
-                    && !app.is_loading()
-                    && app.selected().is_some()
-                {
-                    app.enter_view_mode(content_width, providers);
-                    continue;
-                }
-
-                if let Some(action) =
-                    app.handle_key(key.code, key.modifiers, viewport_height, providers)
-                {
-                    match action {
-                        Action::Delete(ref path) => {
-                            // Delete through provider dispatch
-                            let conv = app
-                                .conversations()
-                                .iter()
-                                .find(|c| &c.path == path)
-                                .cloned();
-                            let deleted = if let Some(ref conv) = conv {
-                                if let Some(provider) =
-                                    providers.iter().find(|p| p.kind() == conv.provider)
-                                {
-                                    provider.delete(conv).is_ok()
-                                } else {
-                                    std::fs::remove_file(path).is_ok()
-                                }
-                            } else {
-                                std::fs::remove_file(path).is_ok()
-                            };
-                            if deleted {
-                                app.remove_selected_from_list();
-                                app.exit_view_mode();
-                            } else {
-                                let _ = debug_log::log_debug(&format!(
-                                    "Failed to delete {}",
-                                    path.display(),
-                                ));
-                            }
-                        }
-                        Action::Select(ref path) => {
-                            let _ = debug_log::log_selected_path(path);
-                            return Ok(action);
-                        }
-                        Action::Resume(ref path) => {
-                            let _ = debug_log::log_selected_path(path);
-                            return Ok(action);
-                        }
-                        Action::Quit => return Ok(action),
-                    }
-                }
-            }
-        }
-    }
-}
-
 /// Run the TUI with background loading
 /// Returns the action and the final list of conversations
 pub fn run_with_loader(
@@ -1889,7 +1792,11 @@ pub fn run_with_loader(
                             ));
                         }
                     }
-                    _ => return Ok((action, app.into_conversations())),
+                    Action::Select(ref path) | Action::Resume(ref path) => {
+                        let _ = debug_log::log_selected_path(path);
+                        return Ok((action, app.into_conversations()));
+                    }
+                    Action::Quit => return Ok((action, app.into_conversations())),
                 }
             }
         }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4,5 +4,5 @@ pub(crate) mod search;
 mod ui;
 pub mod viewer;
 
-pub use app::{Action, run, run_single_file, run_with_loader};
+pub use app::{Action, run_single_file, run_with_loader};
 pub use viewer::{RenderOptions, ToolDisplayMode, render_conversation};

--- a/src/tui/viewer.rs
+++ b/src/tui/viewer.rs
@@ -133,7 +133,7 @@ pub fn render_conversation(
 fn render_entry(lines: &mut Vec<RenderedLine>, entry: &LogEntry, options: &RenderOptions) {
     match entry {
         LogEntry::Summary { .. }
-        | LogEntry::FileHistorySnapshot { .. }
+        | LogEntry::FileHistorySnapshot
         | LogEntry::System { .. }
         | LogEntry::Unknown => {}
         LogEntry::Progress { data, .. } => {


### PR DESCRIPTION
## Summary
- scope interactive startup to the current directory tree by default
- add `--global` to restore all-conversation browsing
- share subtree path matching between local scope and `list --cwd`
- update README/help text and add scope/CLI tests

## Verification
- `cargo fmt --check`
- `cargo run -- --help`
- `cargo test`