### PR TITLE
Fix Windows history path resolution

### DIFF
--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -116,18 +116,43 @@ pub enum LoaderMessage {
 
 /// Get the root Claude projects directory (~/.claude/projects)
 pub fn get_claude_projects_root() -> Result<PathBuf> {
-    let home_dir = std::env::var("HOME").map_err(|_| {
+    claude_projects_root_from_home(home::home_dir())
+}
+
+fn claude_projects_root_from_home(home_dir: Option<PathBuf>) -> Result<PathBuf> {
+    let home_dir = home_dir.ok_or_else(|| {
         AppError::Io(std::io::Error::new(
             std::io::ErrorKind::NotFound,
-            "HOME environment variable not set",
+            "home directory not found",
         ))
     })?;
 
-    Ok(PathBuf::from(home_dir).join(".claude").join("projects"))
+    Ok(home_dir.join(".claude").join("projects"))
 }
 
 /// Get the Claude projects directory for the current working directory
 pub fn get_claude_projects_dir(current_dir: &std::path::Path) -> Result<PathBuf> {
     let converted = convert_path_to_project_dir_name(current_dir);
     Ok(get_claude_projects_root()?.join(converted))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_projects_root_uses_resolved_home_dir() {
+        let home = PathBuf::from("home").join("user");
+
+        let root = claude_projects_root_from_home(Some(home.clone())).unwrap();
+
+        assert_eq!(root, home.join(".claude").join("projects"));
+    }
+
+    #[test]
+    fn claude_projects_root_errors_when_home_dir_is_unavailable() {
+        let error = claude_projects_root_from_home(None).unwrap_err();
+
+        assert!(error.to_string().contains("home directory not found"));
+    }
 }

--- a/src/history/path.rs
+++ b/src/history/path.rs
@@ -121,13 +121,44 @@ pub fn resolve_project_dir(path: &Path) -> Option<PathBuf> {
                 return Some(repo);
             }
         }
-        // Nested layout: an ancestor is itself the repo.
-        if is_git_repo(ancestor) {
-            return Some(ancestor.to_path_buf());
+    }
+
+    nested_worktree_repo_candidates(path)
+        .into_iter()
+        .find(|candidate| is_git_repo(candidate))
+}
+
+fn nested_worktree_repo_candidates(path: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+
+    for ancestor in path.ancestors().skip(1) {
+        let Some(name) = ancestor
+            .file_name()
+            .and_then(|name| name.to_str())
+            .map(|name| name.to_ascii_lowercase())
+        else {
+            continue;
+        };
+
+        match name.as_str() {
+            ".worktrees" => {
+                if let Some(repo) = ancestor.parent() {
+                    candidates.push(repo.to_path_buf());
+                }
+            }
+            "worktrees" => {
+                if let Some(parent) = ancestor.parent() {
+                    candidates.push(parent.to_path_buf());
+                    if let Some(grandparent) = parent.parent() {
+                        candidates.push(grandparent.to_path_buf());
+                    }
+                }
+            }
+            _ => {}
         }
     }
 
-    None
+    candidates
 }
 
 /// Detect the worktree-container path components: an exact `worktrees` or
@@ -485,6 +516,19 @@ mod tests {
         assert!(!project_path_is_live(&orphan));
 
         std::fs::remove_dir_all(&repo).unwrap();
+    }
+
+    #[test]
+    fn deleted_worktree_does_not_resolve_to_unrelated_ancestor_repo() {
+        let base = std::env::temp_dir().join("mnemonai_wt_unrelated_ancestor");
+        let _ = std::fs::remove_dir_all(&base);
+        std::fs::create_dir_all(base.join(".git")).unwrap();
+
+        let orphan = base.join("missing/.agent-pr-review/worktrees/pr-4");
+
+        assert!(!project_path_is_live(&orphan));
+
+        std::fs::remove_dir_all(&base).unwrap();
     }
 
     #[test]

--- a/src/providers/cursor_agent.rs
+++ b/src/providers/cursor_agent.rs
@@ -796,22 +796,52 @@ fn resolve_workspace_path(encoded_dir_name: &str, chats_dir: Option<&Path>) -> O
 
     match candidates.len() {
         0 => None,
-        1 => Some(PathBuf::from(candidates.into_iter().next().unwrap())),
+        1 => Some(path_from_dfs_candidate(
+            &candidates.into_iter().next().unwrap(),
+        )),
         _ => {
             // MD5 tiebreaker: check which candidate has a matching chats directory
             if let Some(chats_dir) = chats_dir.filter(|d| d.is_dir()) {
                 for candidate in &candidates {
-                    let hash = format!("{:x}", md5::compute(candidate.as_bytes()));
-                    if chats_dir.join(&hash).is_dir() {
-                        return Some(PathBuf::from(candidate));
+                    if candidate_matches_chat_hash(candidate, chats_dir) {
+                        return Some(path_from_dfs_candidate(candidate));
                     }
                 }
             }
             // Fall back to the longest path (most specific)
             candidates.sort_by_key(|b| std::cmp::Reverse(b.len()));
-            Some(PathBuf::from(candidates.into_iter().next().unwrap()))
+            Some(path_from_dfs_candidate(
+                &candidates.into_iter().next().unwrap(),
+            ))
         }
     }
+}
+
+fn candidate_matches_chat_hash(candidate: &str, chats_dir: &Path) -> bool {
+    let path_string = path_from_dfs_candidate(candidate)
+        .to_string_lossy()
+        .to_string();
+    [candidate, path_string.as_str()].into_iter().any(|input| {
+        let hash = format!("{:x}", md5::compute(input.as_bytes()));
+        chats_dir.join(hash).is_dir()
+    })
+}
+
+fn path_from_dfs_candidate(candidate: &str) -> PathBuf {
+    let mut parts = candidate.split('/').filter(|part| !part.is_empty());
+    let Some(first) = parts.next() else {
+        return PathBuf::from(candidate);
+    };
+
+    let mut path = if candidate.starts_with('/') {
+        PathBuf::from(format!("/{first}"))
+    } else {
+        PathBuf::from(first)
+    };
+    for part in parts {
+        path.push(part);
+    }
+    path
 }
 
 /// DFS over hyphen positions, trying each `-` as either a path separator (`/`)


### PR DESCRIPTION
## Summary
- resolve Claude projects via the platform home directory instead of requiring HOME
- bound deleted-worktree fallback to known worktree container layouts
- normalize Cursor Agent DFS candidates before MD5 chat hash matching on Windows

## Tests
- cargo fmt --all -- --check
- cargo test --all --release